### PR TITLE
Fix crash on loading invalid textures

### DIFF
--- a/src/C4Texture.cpp
+++ b/src/C4Texture.cpp
@@ -120,6 +120,8 @@ bool C4TextureMap::AddEntry(uint8_t byIndex, const char *szMaterial, const char 
 	// Security
 	if (byIndex <= 0 || byIndex >= C4M_MaxTexIndex)
 		return false;
+	if (!szMaterial || !szTexture)
+		return false;
 	// Set entry and initialize
 	Entry[byIndex].Create(szMaterial, szTexture);
 	if (fInitialized)


### PR DESCRIPTION
A material specification that omits the texture specification
(e.g. 10=Tunnel) would cause a crash.