### PR TITLE
Adds support for XDG base directories on Linux

### DIFF
--- a/src/C4Config.h
+++ b/src/C4Config.h
@@ -67,6 +67,9 @@ public:
 	int32_t ConfigResetSafety; // safety value: If this value is screwed, the config got currupted and must be reset
 	// Determined at run-time
 	char ExePath[CFG_MaxString + 1];
+#ifdef __linux__
+	char XDG_CONFIG_PATH[CFG_MaxString + 1];
+#endif
 	char TempPath[CFG_MaxString + 1];
 	char LogPath[CFG_MaxString + 1];
 	char ScreenshotPath[CFG_MaxString + 1];
@@ -267,7 +270,7 @@ public:
 	bool Save();
 	bool Load(bool forceWorkingDirectory = true, const char *szConfigFile = nullptr);
 	bool Init();
-	const char *AtExePath(const char *szFilename);
+	const char *AtExePath(const char *szFilename, bool forceExeFolder=false);
 	const char *AtTempPath(const char *szFilename);
 	const char *AtNetworkPath(const char *szFilename);
 	const char *AtExeRelativePath(const char *szFilename);

--- a/src/C4Group.cpp
+++ b/src/C4Group.cpp
@@ -670,6 +670,35 @@ bool C4Group::Open(const char *szGroupName, bool fCreate)
 		// Open group or folder
 		return OpenReal(szGroupNameN);
 	}
+#ifdef __linux__
+	else
+	// check if file exists in user data directory
+    {
+        StdStrBuf data_directory(getenv("XDG_DATA_HOME"));
+	    if (!data_directory.getSize()) {
+	        data_directory = getenv("HOME");
+	        data_directory += "/.local/share";
+	    }
+	    data_directory += "/legacyclonk/";
+	    StdStrBuf filename = data_directory + szGroupNameN;
+	    if (FileExists(filename.getData()))
+        {
+	        Init();
+	        return OpenReal(filename.getData());
+        }
+	    // check if file exists in system distribution directory
+	    filename = "/usr/share/legacyclonk/";
+	    filename += szGroupNameN;
+	    if (FileExists(filename.getData()))
+        {
+	        Init();
+	        return OpenReal(filename.getData());
+        }
+
+	}
+#endif
+
+
 
 	// If requested, try creating a new group file
 	if (fCreate)

--- a/src/C4LoaderScreen.cpp
+++ b/src/C4LoaderScreen.cpp
@@ -68,7 +68,11 @@ bool C4LoaderScreen::Init(const char *szLoaderSpec)
 	{
 		// open it
 		GfxGrp.Close();
-		if (!GfxGrp.Open(Config.AtExePath(C4CFN_Graphics)))
+		if (!GfxGrp.Open(Config.AtExePath(C4CFN_Graphics))
+#ifdef __linux__
+&& !GfxGrp.Open(C4CFN_Graphics) // attempt to load graphics from system / user data folder
+#endif
+)
 		{
 			LogFatal(FormatString(LoadResStr("IDS_PRC_NOGFXFILE"), C4CFN_Graphics, GfxGrp.GetError()).getData());
 			return false;

--- a/src/C4Log.cpp
+++ b/src/C4Log.cpp
@@ -37,7 +37,14 @@ StdStrBuf sFatalError;
 bool OpenLog()
 {
 	// open
-	sLogFileName = C4CFN_Log; int iLog = 2;
+#ifndef __linux__
+	sLogFileName = C4CFN_Log;
+#else
+	sLogFileName  = Config.General.XDG_CONFIG_PATH;
+	sLogFileName.Append("/");
+	sLogFileName.Append(C4CFN_Log);
+#endif
+	int iLog = 2;
 #ifdef _WIN32
 	while (!(C4LogFile = _fsopen(sLogFileName.getData(), "wt", _SH_DENYWR)))
 #else
@@ -45,7 +52,13 @@ bool OpenLog()
 #endif
 	{
 		// try different name
+#ifndef __linux__
 		sLogFileName.Format(C4CFN_LogEx, iLog++);
+#else
+		sLogFileName = Config.General.XDG_CONFIG_PATH;
+		sLogFileName.Append("/");
+		sLogFileName.AppendFormat(C4CFN_LogEx, iLog++);
+#endif
 	}
 	// save start time
 	time(&C4LogStartTime);

--- a/src/C4MainMenu.cpp
+++ b/src/C4MainMenu.cpp
@@ -65,7 +65,13 @@ bool C4MainMenu::ActivateNewPlayer(int32_t iPlayer)
 	if (GfxR->fctPlayerClr.Surface)
 		GfxR->fctPlayerClr.Surface->SetClr(0xff);
 	InitRefSym(GfxR->fctPlayerClr, LoadResStr("IDS_MENU_NOPLRFILES"), iPlayer);
+#ifndef __linux__
 	for (DirectoryIterator iter(Config.General.PlayerPath); *iter; ++iter)
+#else
+	StdStrBuf search_path(Config.General.XDG_CONFIG_PATH);
+	search_path += Config.General.PlayerPath;
+    for (DirectoryIterator iter(search_path.getData()); *iter; ++iter)
+#endif
 		if (WildcardMatch("*.c4p", *iter))
 		{
 			char szFilename[_MAX_PATH + 1], szCommand[_MAX_PATH + 30 + 1];

--- a/src/C4SoundSystem.cpp
+++ b/src/C4SoundSystem.cpp
@@ -404,7 +404,15 @@ bool C4SoundSystem::Init()
 	ClearEffects();
 	// Open sound file
 	if (!SoundFile.IsOpen())
-		if (!SoundFile.Open(Config.AtExePath(C4CFN_Sound))) return false;
+		if (!SoundFile.Open(Config.AtExePath(C4CFN_Sound))
+#ifdef __linux__
+&& !SoundFile.Open(C4CFN_Sound)
+#endif
+)
+        {
+		    return false;
+        }
+
 #ifdef HAVE_LIBSDL_MIXER
 	Mix_AllocateChannels(C4MaxSoundInstances);
 #endif

--- a/src/C4StartupMainDlg.cpp
+++ b/src/C4StartupMainDlg.cpp
@@ -283,7 +283,13 @@ void C4StartupMainDlg::OnShown()
 	// first thing that's needed is a new player, if there's none - independent of first start
 	bool fHasPlayer = false;
 	StdStrBuf sSearchPath; const char *szFn;
+#ifndef __linux__
 	sSearchPath.Format("%s%s", (const char *)Config.General.ExePath, (const char *)Config.General.PlayerPath);
+#else
+	// search in user config directory instead.
+	sSearchPath.Format("%s%s", (const char*)Config.General.XDG_CONFIG_PATH, (const char*)Config.General.PlayerPath);
+#endif
+
 	for (DirectoryIterator i(sSearchPath.getData()); szFn = *i; i++)
 	{
 		szFn = Config.AtExeRelativePath(szFn);

--- a/src/C4StartupPlrSelDlg.cpp
+++ b/src/C4StartupPlrSelDlg.cpp
@@ -694,7 +694,12 @@ void C4StartupPlrSelDlg::UpdatePlayerList()
 		// player mode: insert all players
 		const char *szFn;
 		StdStrBuf sSearchPath;
+#ifndef __linux__
 		sSearchPath.Format("%s%s", (const char *)Config.General.ExePath, (const char *)Config.General.PlayerPath);
+#else
+        sSearchPath.Format("%s%s", (const char *)Config.General.XDG_CONFIG_PATH, (const char *)Config.General.PlayerPath);
+#endif
+
 		PlayerListItem *pFirstActivatedPlrItem = nullptr, *pFirstDeactivatedPlrItem = nullptr, *pPlrItem = nullptr;
 		for (DirectoryIterator i(sSearchPath.getData()); szFn = *i; i++)
 		{
@@ -897,7 +902,12 @@ bool C4StartupPlrSelDlg::CheckPlayerName(const StdStrBuf &Playername, StdStrBuf 
 	SReplaceChar(Filename.getMData(), '|', '_');
 	if (*Filename.getData() == '.') *Filename.getMData() = '_';
 	Filename.Append(".c4p");
+#ifndef __linux__
 	StdStrBuf Path(""); // start at local path
+#else
+    StdStrBuf Path(Config.General.XDG_CONFIG_PATH);
+    Path.Append("/"); // start at config dir
+#endif
 	Path.Append(Config.General.PlayerPath);
 	Path.Append(Filename);
 	// validity check: Must not exist yet if renamed

--- a/src/C4StartupScenSelDlg.cpp
+++ b/src/C4StartupScenSelDlg.cpp
@@ -1400,6 +1400,21 @@ void C4StartupScenSelDlg::OnShown()
 	pScenLoader->Load(StdStrBuf(Config.General.ExePath));
 	UpdateList();
 	UpdateSelection();
+#ifdef __linux__
+	StdStrBuf data_folder(getenv("XDG_CONFIG_DATA"));
+	if (!data_folder.getSize()){
+	    data_folder = getenv("HOME");
+	    data_folder += "/.local/share/legacyclonk";
+	}
+    data_folder += "/";
+	pScenLoader->Load(data_folder);
+	UpdateList();
+	UpdateSelection();
+	data_folder = "/usr/share/legacyclonk/";
+	pScenLoader->Load(data_folder);
+	UpdateList();
+	UpdateSelection();
+#endif
 	fIsInitialLoading = false;
 	// network activation by dialog type
 	Game.NetworkActive = fStartNetworkGame;


### PR DESCRIPTION
related issue: #18 
Includes $XDG_PICTURES_DIR for screenshots, $XDG_CONFIG_DIR for
configurations, and $XDG_DATA_DIR for game data.
Game data is loaded from $XDG_DATA_DIR/legacyclonk first,
/usr/share/legacyclonk second.
In my (admittedly limited) testing this worked without issues, including being able to load different scenarios.