### PR TITLE
Adding support for .ogg autocompletion

### DIFF
--- a/src/C4SoundSystem.h
+++ b/src/C4SoundSystem.h
@@ -118,6 +118,7 @@ private:
 		bool IsNear(const C4Object &obj) const;
 	};
 
+	static const std::string fileExtensions[];
 	static constexpr std::int32_t MaxSoundInstances = 20;
 	std::list<Sample> samples;
 
@@ -131,7 +132,7 @@ private:
 	Instance *NewInstance(const char *filename, bool loop,
 		std::int32_t volume, std::int32_t pan, C4Object *obj, std::int32_t falloffDistance);
 	// Adds default file extension if missing and replaces "*" with "?"
-	static std::string PrepareFilename(const char *filename);
+	static std::string PrepareFilename(const char *const filename, std::string fileExtension);
 
 	friend bool IsSoundPlaying(const char *, const C4Object *);
 	friend void SoundLevel(const char *, C4Object *, std::int32_t);


### PR DESCRIPTION
This pull request fixes #41. With support of "Client" I've implemented an autocompletion for .ogg files. I've also implemented finding instances of running ogg sounds (::FindInst()) to make the system able to stop them. The function PrepareFilename() is extended with one argument to apply a desired file extension as fallback. Finally I've refactored the code and removed duplicated ".wav" strings spreaded in the file to a private class-scoped string array "fileExtensions" and added a missing const in declaring the function PrepareFilename().