### PR TITLE
Fix arrow-key scrolling while game is paused

### DIFF
--- a/src/C4GraphicsSystem.cpp
+++ b/src/C4GraphicsSystem.cpp
@@ -873,12 +873,11 @@ bool C4GraphicsSystem::FreeScroll(C4Vec2D vScrollBy)
 	// move then (old static code crap...)
 	static int32_t vp_vx = 0; static int32_t vp_vy = 0;
 	int32_t dx = vScrollBy.x; int32_t dy = vScrollBy.y;
-	if (!MostRecentScrolling.Elapsed())
+	if (!MostRecentScrolling.TryReset())
 	{
 		dx += vp_vx; dy += vp_vy;
 	}
 	vp_vx = dx; vp_vy = dy;
 	vp->ViewX += dx; vp->ViewY += dy;
-	MostRecentScrolling.Reset();
 	return true;
 }

--- a/src/C4GraphicsSystem.cpp
+++ b/src/C4GraphicsSystem.cpp
@@ -873,11 +873,12 @@ bool C4GraphicsSystem::FreeScroll(C4Vec2D vScrollBy)
 	// move then (old static code crap...)
 	static int32_t vp_vx = 0; static int32_t vp_vy = 0;
 	int32_t dx = vScrollBy.x; int32_t dy = vScrollBy.y;
-	if (!MostRecentScrolling.TryReset())
+	if (!MostRecentScrolling.Elapsed())
 	{
 		dx += vp_vx; dy += vp_vy;
 	}
 	vp_vx = dx; vp_vy = dy;
 	vp->ViewX += dx; vp->ViewY += dy;
+	MostRecentScrolling.Reset();
 	return true;
 }

--- a/src/C4GraphicsSystem.cpp
+++ b/src/C4GraphicsSystem.cpp
@@ -877,7 +877,6 @@ bool C4GraphicsSystem::FreeScroll(C4Vec2D vScrollBy)
 	{
 		dx += vp_vx; dy += vp_vy;
 	}
-	LogF("Deltas:    %3i, %3i   \nPrevious: %3i, %3i", dx, dy, vp_vx, vp_vy);
 	vp_vx = dx; vp_vy = dy;
 	vp->ViewX += dx; vp->ViewY += dy;
 	MostRecentScrolling.Reset();

--- a/src/C4GraphicsSystem.cpp
+++ b/src/C4GraphicsSystem.cpp
@@ -871,13 +871,15 @@ bool C4GraphicsSystem::FreeScroll(C4Vec2D vScrollBy)
 	if (Viewports.empty()) return false;
 	const auto &vp = Viewports.front();
 	// move then (old static code crap...)
-	static int32_t vp_vx = 0; static int32_t vp_vy = 0; static int32_t vp_vf = 0;
+	static int32_t vp_vx = 0; static int32_t vp_vy = 0;
 	int32_t dx = vScrollBy.x; int32_t dy = vScrollBy.y;
-	if (Game.FrameCounter - vp_vf < 5)
+	if (!MostRecentScrolling.Elapsed())
 	{
 		dx += vp_vx; dy += vp_vy;
 	}
-	vp_vx = dx; vp_vy = dy; vp_vf = Game.FrameCounter;
+	LogF("Deltas:    %3i, %3i   \nPrevious: %3i, %3i", dx, dy, vp_vx, vp_vy);
+	vp_vx = dx; vp_vy = dy;
 	vp->ViewX += dx; vp->ViewY += dy;
+	MostRecentScrolling.Reset();
 	return true;
 }

--- a/src/C4GraphicsSystem.h
+++ b/src/C4GraphicsSystem.h
@@ -22,6 +22,7 @@
 #include <C4MessageBoard.h>
 #include <C4UpperBoard.h>
 #include <C4Shape.h>
+#include <C4Cooldown.h>
 
 #include <memory>
 #include <vector>
@@ -50,6 +51,8 @@ public:
 	uint32_t dwGamma[C4MaxGammaRamps * 3]; // gamma ramps
 	bool fSetGamma; // must gamma ramp be reassigned?
 	C4LoaderScreen *pLoaderScreen;
+	//used to determine if arrow keys are held in FreeScroll()
+	C4Cooldown<std::chrono::milliseconds::rep, std::chrono::milliseconds::period> MostRecentScrolling{std::chrono::milliseconds{100}}; 
 	void Default();
 	void Clear();
 	bool StartDrawing();


### PR DESCRIPTION
Previously FreeScroll() checked Game.FrameCounter to see if it is being called repetitively(i. e. the key is most likely pressed down). This does not work when the game is paused, as Game.FrameCounter does not increase. This PR replaces it with a C4Cooldown.
I chose 100 ms arbitrarily as it's close(a bit less) to what the game used previously and was low enough to not trigger when I pressed the key as fast as I could(users may want to do this to nudge the viewport precisely for a screenshot)

I've tested this, debug logging is in the first commit.

Fixes #40 