### PR TITLE
Custom hud bars

### DIFF
--- a/cmake/filelists/Engine.txt
+++ b/cmake/filelists/Engine.txt
@@ -107,6 +107,8 @@ src/C4GuiLabels.cpp
 src/C4GuiListBox.cpp
 src/C4GuiMenu.cpp
 src/C4GuiTabular.cpp
+src/C4HudBars.cpp
+src/C4HudBars.h
 src/C4IDList.cpp
 src/C4IDList.h
 src/C4Id.cpp

--- a/src/C4Facet.cpp
+++ b/src/C4Facet.cpp
@@ -349,7 +349,7 @@ void C4Facet::DrawXT(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iWdt,
 }
 #endif // C4ENGINE
 
-void C4Facet::DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &gfx, int32_t bar_idx)
+void C4Facet::DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &gfx, int32_t bar_idx, float scale)
 {
 #ifdef C4ENGINE
 	// draw energy level using graphics
@@ -402,7 +402,7 @@ void C4Facet::DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &g
 		// draw it; partially if necessary
 		gfx_draw.Y = gfx.Y + vidx * h + dy;
 		gfx_draw.Hgt = dh;
-		gfx_draw.Draw(Surface, X, Y + iY, bar_idx + bar_idx + !filled);
+		gfx_draw.Draw(Surface, X, Y + iY, bar_idx + bar_idx + !filled, 0, scale);
 		iY += dh;
 	}
 #endif

--- a/src/C4Facet.h
+++ b/src/C4Facet.h
@@ -129,7 +129,7 @@ public:
 	void Default();
 	void Set(C4Surface *nsfc, int32_t nx, int32_t ny, int32_t nwdt, int32_t nhgt);
 	void Set(const C4Facet &cpy) { *this = cpy; }
-	void DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &gfx, int32_t bar_idx); // draw energy level using graphics
+	void DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &gfx, int32_t bar_idx, float scale); // draw energy level using graphics
 	void DrawX(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iWdt, int32_t iHgt, int32_t iPhaseX = 0, int32_t iPhaseY = 0, float scale = 1.0f) const;
 	void DrawXFloat(C4Surface *sfcTarget, float fX, float fY, float fWdt, float fHgt) const;
 	void DrawValue(C4Facet &cgo, int32_t iValue, int32_t iPhaseX = 0, int32_t iPhaseY = 0, int32_t iAlign = C4FCT_Center);

--- a/src/C4Game.cpp
+++ b/src/C4Game.cpp
@@ -26,6 +26,7 @@
 #include <C4GameSave.h>
 #include <C4Record.h>
 #include <C4Application.h>
+#include <C4HudBars.h>
 #include <C4Object.h>
 #include <C4ObjectInfo.h>
 #include <C4Random.h>

--- a/src/C4Game.h
+++ b/src/C4Game.h
@@ -29,6 +29,7 @@
 #include <C4MouseControl.h>
 #include <C4MessageInput.h>
 #include <C4Weather.h>
+#include <C4HudBars.h>
 #include <C4Material.h>
 #include <C4GameObjects.h>
 #include <C4Landscape.h>
@@ -179,6 +180,8 @@ public:
 	bool fQuitWithError; // if set, game shut down irregularly
 	bool IsMusicEnabled;
 	int32_t iMusicLevel; // scenario-defined music level
+	C4HudBarsUniquifier HudBars;
+
 	// current play list
 	StdStrBuf PlayList;
 	bool DebugMode;

--- a/src/C4GraphicsResource.cpp
+++ b/src/C4GraphicsResource.cpp
@@ -68,7 +68,6 @@ void C4GraphicsResource::Default()
 	fctHand.Default();
 	fctGamepad.Default();
 	fctBuild.Default();
-	fctEnergyBars.Default();
 
 	std::fill(GamePalette, std::end(GamePalette), 0);
 	std::fill(AlphaPalette, std::end(AlphaPalette), 0);
@@ -129,7 +128,6 @@ void C4GraphicsResource::Clear()
 	fctHand.Clear();
 	fctGamepad.Clear();
 	fctBuild.Clear();
-	fctEnergyBars.Clear();
 
 	// unhook deflist from font
 	FontRegular.SetCustomImages(nullptr);
@@ -227,17 +225,8 @@ bool C4GraphicsResource::Init(bool fInitGUI)
 	if (!LoadFile(fctHand,            "Hand",         Files, C4FCT_Height))         return false;
 	if (!LoadFile(fctGamepad,         "Gamepad",      Files, 80))                   return false;
 	if (!LoadFile(fctBuild,           "Build",        Files))                       return false;
-	if (!LoadFile(fctEnergyBars,      "EnergyBars",   Files))                       return false;
 	if (!LoadFile(sfcLiquidAnimation, "Liquid",       Files, idSfcLiquidAnimation)) return false;
 	if (!ReloadResolutionDependentFiles()) return false;
-	// life bar facets
-	if (fctEnergyBars.Surface)
-	{
-		int32_t bar_wdt = fctEnergyBars.Surface->Wdt / 6;
-		int32_t bar_hgt = fctEnergyBars.Surface->Hgt / 3;
-		if (!bar_wdt || !bar_hgt) { LogFatal("EnergyBars.png invalid or too small!"); return false; }
-		fctEnergyBars.Set(fctEnergyBars.Surface, 0, 0, bar_wdt, bar_hgt);
-	}
 
 	// create ColorByOwner overlay surfaces
 	if (fctCrew.idSourceGroup != fctCrewClr.idSourceGroup)

--- a/src/C4GraphicsResource.h
+++ b/src/C4GraphicsResource.h
@@ -73,7 +73,6 @@ public:
 	C4FacetExID fctHand;
 	C4FacetExID fctGamepad;
 	C4FacetExID fctBuild;
-	C4FacetExID fctEnergyBars;
 	C4Facet fctCursor;
 	C4Facet fctDropTarget;
 	C4Facet fctInsideSymbol;
@@ -108,8 +107,8 @@ public:
 
 	bool ReloadResolutionDependentFiles(); // reload any files that depend on the current resolution
 
-protected:
 	bool LoadFile(C4FacetExID &fct, const char *szName, C4GroupSet &rGfxSet, int32_t iWdt = C4FCT_Full, int32_t iHgt = C4FCT_Full, bool fNoWarnIfNotFound = false);
+protected:
 	bool LoadFile(C4Surface &sfc, const char *szName, C4GroupSet &rGfxSet, int32_t &ridCurrSfc);
 	bool LoadCursorGfx();
 	void ApplyCursorGfx();

--- a/src/C4HudBars.cpp
+++ b/src/C4HudBars.cpp
@@ -1,0 +1,679 @@
+/*
+ * LegacyClonk
+ *
+ * Copyright (c) 2021, The LegacyClonk Team and contributors
+ *
+ * Distributed under the terms of the ISC license; see accompanying file
+ * "COPYING" for details.
+ *
+ * "Clonk" is a registered trademark of Matthes Bender, used with permission.
+ * See accompanying file "TRADEMARK" for details.
+ *
+ * To redistribute this file separately, substitute the full license texts
+ * for the above references.
+ */
+
+#include "C4HudBars.h"
+
+#include "C4Include.h"
+
+#include "C4Def.h"
+#include "C4Game.h"
+#include "C4Log.h"
+#include "C4Object.h"
+#include "C4ValueList.h"
+#include "C4ValueHash.h"
+#include "C4Wrappers.h"
+
+#include "StdHelpers.h"
+
+C4HudBar::C4HudBar() noexcept
+  : value{0}, max{1000000}, visible{true}
+{}
+
+C4HudBar::C4HudBar(std::int32_t value, std::int32_t max, bool visible) noexcept
+	: value{value}, max{max}, visible{visible}
+{}
+
+bool C4HudBar::operator==(const C4HudBar &rhs) const noexcept
+{
+	return value == rhs.value && max == rhs.max && visible == rhs.visible;
+}
+
+void C4HudBar::CompileFunc(StdCompiler *comp)
+{
+	comp->Value(mkNamingAdapt(value, "Value", 0));
+	comp->Value(mkNamingAdapt(max, "Max", 1000000));
+	comp->Value(mkNamingAdapt(visible, "Visible", true));
+}
+
+
+C4HudBars::C4HudBars(std::shared_ptr<const C4HudBarsDef> def) noexcept : def{def}
+{
+	for (const auto &bardef : def->bars)
+	{
+		if (bardef.physical == C4HudBarDef::EBP_None)
+			values.emplace_back(bardef.value, bardef.max, bardef.visible);
+	}
+}
+
+C4HudBar *C4HudBars::BarVal(C4AulContext *cthr, const char *functionName, const std::string &name)
+{
+	try
+	{
+		const auto index = def->names.at(name);
+		auto &bardef = def->bars.at(index);
+		if (bardef.value_index >= 0)
+		{
+			return &values.at(bardef.value_index);
+		}
+		else
+		{
+			throw C4AulExecError{cthr->Obj, FormatString("%s: bar \"%s\" is based on physical and can not be set directly.", functionName, name.c_str()).getData()};
+		}
+	}
+	catch (const std::out_of_range &)
+	{
+		throw C4AulExecError{cthr->Obj, FormatString("%s: bar \"%s\" was not defined.", functionName, name.c_str()).getData()};
+	}
+
+	// should never get here
+	throw C4AulExecError{cthr->Obj, FormatString("%s: bar \"%s\" an unexpected error occured.", functionName, name.c_str()).getData()};
+}
+
+void C4HudBars::SetHudBarValue(C4AulContext *cthr, const std::string &name, std::int32_t value, std::int32_t max)
+{
+	const auto barval = BarVal(cthr, "SetHudBarValue", name);
+	barval->value = value;
+	if(max > 0) barval->max = max;
+}
+
+void C4HudBars::SetHudBarVisibility(C4AulContext *cthr, const std::string &name, bool visible)
+{
+	const auto barval = BarVal(cthr, "SetHudBarVisibility", name);
+	barval->visible = visible;
+}
+
+void C4HudBars::DrawHudBars(C4Facet &cgo, C4Object &obj) const noexcept
+{
+	bool needsAdvance = false;
+	std::int32_t maxWidth = 0;
+
+	for (const auto &bardef : def->bars)
+	{
+		std::int32_t value{0};
+		std::int32_t max{0};
+		bool visible{true};
+		const bool hideHUDBars = bardef.hide & C4HudBarDef::EBH_HideHUDBars;
+
+		switch(bardef.physical)
+		{
+		case C4HudBarDef::EBP_Energy:
+			if (hideHUDBars && obj.Def->HideHUDBars & C4Def::HB_Energy) visible = false;
+			value = obj.Energy;
+			max = obj.GetPhysical()->Energy;
+			break;
+		case C4HudBarDef::EBP_Breath:
+			if (hideHUDBars && obj.Def->HideHUDBars & C4Def::HB_Breath) visible = false;
+			value = obj.Breath;
+			max = obj.GetPhysical()->Breath;
+			break;
+		case C4HudBarDef::EBP_Magic:
+			if (hideHUDBars && obj.Def->HideHUDBars & C4Def::HB_MagicEnergy) visible = false;
+			// draw in units of MagicPhysicalFactor, so you can get a full magic energy bar by script even if partial magic energy training is not fulfilled
+			value = obj.MagicEnergy / MagicPhysicalFactor;
+			max = obj.GetPhysical()->Magic / MagicPhysicalFactor;
+			break;
+		default:
+			const auto &barval = values.at(bardef.value_index);
+			value = barval.value;
+			max   = barval.max;
+			visible = barval.visible;
+			break;
+		}
+
+		if (bardef.hide & C4HudBarDef::EBH_Empty && value == 0)   visible = false;
+		if (bardef.hide & C4HudBarDef::EBH_Full  && value >= max) visible = false;
+
+		if (!visible)
+		{
+			if (needsAdvance && bardef.advance)
+			{
+				cgo.X += maxWidth;
+				maxWidth = 0;
+				needsAdvance = false;
+			}
+			continue;
+		}
+
+		const std::int32_t width = bardef.facet->Wdt;
+		cgo.Wdt = width;
+		cgo.DrawEnergyLevelEx(value, max, *bardef.facet, bardef.index, bardef.scale);
+
+		maxWidth = std::max<std::int32_t>(maxWidth, width + 1);
+		if (bardef.advance)
+		{
+			cgo.X += maxWidth;
+			maxWidth = 0;
+			needsAdvance = false;
+		}
+		else
+		{
+			needsAdvance = true;
+		}
+	}
+}
+
+
+C4HudBarDef::C4HudBarDef() noexcept :
+	physical{EBP_None}, hide{EBH_Empty}, index{}, advance{true},
+	value_index{-1}, value{0}, max{1000000}, visible{true}, scale{1.0f}
+{}
+
+C4HudBarDef::C4HudBarDef(std::string_view name, std::string_view gfx, const std::shared_ptr<C4FacetExID> &facet, std::int32_t index, Physical physical) :
+	name{name}, physical{physical}, hide{DefaultHide(physical)},
+	gfx{gfx}, facet{facet}, index{index}, advance{true},
+	value_index{-1}, value{0}, max{1000000}, visible{true}, scale{1.0f}
+{}
+
+bool C4HudBarDef::operator==(const C4HudBarDef &rhs) const noexcept
+{
+	return
+		name == rhs.name &&
+		physical == rhs.physical &&
+		hide == rhs.hide &&
+		gfx == rhs.gfx &&
+		facet == rhs.facet &&
+		index == rhs.index &&
+		advance == rhs.advance &&
+		value == rhs.value &&
+		max == rhs.max &&
+		visible == rhs.visible;
+}
+
+C4HudBarDef::Hide C4HudBarDef::DefaultHide(C4HudBarDef::Physical physical) noexcept
+{
+	switch (physical)
+	{
+	case EBP_Energy: return EBH_Never | EBH_HideHUDBars;
+	case EBP_Breath: return EBH_Full | EBH_HideHUDBars;
+	case EBP_Magic:
+	default:
+		return EBH_Empty | EBH_HideHUDBars;
+	}
+}
+
+int32_t C4HudBarDef::DefaultIndex(C4HudBarDef::Physical physical) noexcept
+{
+	switch (physical)
+	{
+	case EBP_Energy: return 0;
+	case EBP_Magic:  return 1;
+	case EBP_Breath: return 2;
+	default:
+		return 0;
+	}
+}
+
+std::size_t C4HudBarDef::GetHash() const noexcept
+{
+	std::size_t result = std::hash<std::string>{}(name);
+	HashCombine(result, std::hash<std::int32_t>{}(physical));
+	HashCombine(result, std::hash<std::int32_t>{}(hide));
+	HashCombine(result, std::hash<std::string>{}(gfx));
+	HashCombine(result, std::hash<std::int32_t>{}(index));
+	HashCombine(result, std::hash<bool>{}(advance));
+	HashCombine(result, std::hash<std::int32_t>{}(value_index));
+	HashCombine(result, std::hash<std::int32_t>{}(value));
+	HashCombine(result, std::hash<std::int32_t>{}(max));
+	HashCombine(result, std::hash<bool>{}(visible));
+	return result;
+}
+
+void C4HudBarDef::CompileFunc(StdCompiler *comp)
+{
+	comp->Value(mkNamingAdapt(name, "Name"));
+	StdEnumEntry<Physical> PhysicalEntries[] =
+	{
+		{ "Energy", EBP_Energy },
+		{ "Magic",  EBP_Magic },
+		{ "Breath", EBP_Breath },
+	};
+	comp->Value(mkNamingAdapt(mkEnumAdaptT<std::uint8_t>(physical, PhysicalEntries), "Physical", EBP_None));
+	StdBitfieldEntry<std::uint8_t> HideEntries[] =
+	{
+		{ "HideHud", EBH_HideHUDBars },
+		{ "Empty",   EBH_Empty },
+		{ "Full",    EBH_Full },
+	};
+
+	std::uint8_t hideVal = hide;
+	comp->Value(mkNamingAdapt(mkBitfieldAdapt<std::uint8_t>(hideVal, HideEntries), "Hide", EBH_Empty));
+	hide = static_cast<Hide>(hideVal);
+
+	comp->Value(mkNamingAdapt(gfx, "Gfx"));
+	comp->Value(mkNamingAdapt(index, "Index"));
+	comp->Value(mkNamingAdapt(advance, "Advance", true));
+	comp->Value(mkNamingAdapt(value_index, "ValueIndex", -1));
+	comp->Value(mkNamingAdapt(value, "Value", 0));
+	comp->Value(mkNamingAdapt(max, "Max", 1000000));
+	comp->Value(mkNamingAdapt(visible, "Visible", true));
+	// gfx and scale are restored from def.gfxs
+}
+
+namespace
+{
+	template <typename Map>
+	bool MapCompare(const Map &lhs, const Map &rhs) noexcept
+	{
+		return lhs.size() == rhs.size()
+			&& std::equal(lhs.begin(), lhs.end(), rhs.begin());
+	}
+}
+
+C4HudBarsDef::Gfx::Gfx() noexcept : key{}, file{}, amount{0}, scale{0} {}
+
+C4HudBarsDef::Gfx::Gfx(std::string key, std::string file, std::int32_t amount, std::int32_t scale) noexcept : key{key}, file{file}, amount{amount}, scale{scale} {}
+
+bool C4HudBarsDef::Gfx::operator==(const Gfx &rhs) const noexcept
+{
+	return key == rhs.key && file == rhs.file && amount == rhs.amount && scale == rhs.scale;
+}
+
+void C4HudBarsDef::Gfx::CompileFunc(StdCompiler *comp)
+{
+	comp->Value(mkNamingAdapt(key, "Key"));
+	comp->Value(mkNamingAdapt(file, "File"));
+	comp->Value(mkNamingAdapt(amount, "Amount"));
+	comp->Value(mkNamingAdapt(scale, "Scale"));
+}
+
+C4HudBarsDef::C4HudBarsDef(Gfxs &&gfxs, Bars &&bars) : gfxs{std::move(gfxs)}, bars{std::move(bars)}
+{
+	PopulateNamesFromValues([](StdStrBuf msg) { LogFatal(msg.getData()); }, this->bars, names);
+}
+
+C4HudBarsDef::C4HudBarsDef(const Gfxs &gfxs, const C4HudBarsDef::Bars &bars, const C4HudBarsDef::Names &names) : gfxs{gfxs}, bars{bars}, names{names} {}
+
+void C4HudBarsDef::PopulateNamesFromValues(const std::function<void(StdStrBuf)> &error, const C4HudBarsDef::Bars &bars, C4HudBarsDef::Names &names)
+{
+	std::int32_t i{0};
+	for (const auto &bar : bars)
+	{
+		const auto success = names.emplace(bar.name, i);
+		if (!success.second)
+		{
+			error(FormatString("C4HudBarsDef %s definition, names must be unique, duplicate detected", bar.name.c_str()));
+		}
+		++i;
+	}
+}
+
+bool C4HudBarsDef::operator==(const C4HudBarsDef &rhs) const noexcept
+{
+	return MapCompare(gfxs, rhs.gfxs) && bars == rhs.bars;
+}
+
+std::size_t C4HudBarsDef::GetHash() const noexcept
+{
+	std::size_t result = 0;
+	for (const auto &gfx : gfxs)
+	{
+		HashCombine(result, std::hash<std::string>{}(gfx.second.key));
+		HashCombine(result, std::hash<std::string>{}(gfx.second.file));
+		HashCombine(result, std::hash<std::uint32_t>{}(gfx.second.amount));
+		HashCombine(result, std::hash<std::uint32_t>{}(gfx.second.scale));
+	}
+
+	for (const auto &bardef : bars)
+		HashCombine(result, bardef.GetHash());
+
+	return result;
+}
+
+std::size_t std::hash<const C4HudBarsDef>::operator()(const C4HudBarsDef &value) const noexcept
+{
+	return value.GetHash();
+}
+
+
+std::shared_ptr<C4HudBars> C4HudBarsUniquifier::DefaultBars()
+{
+	if (!defaultBars)
+	{
+		constexpr auto file = "EnergyBars";
+		C4HudBarsDef::Gfxs gfxs{{file, C4HudBarsDef::Gfx{file, file, 3, 100}}};
+		const auto gfx = GetFacet([file](StdStrBuf msg) { LogFatal(FormatString("could not load default hud bars \"%s\"", file).getData()); }, gfxs, file);
+		const auto def = UniqueifyDefinition
+		(
+			std::make_unique<C4HudBarsDef>
+			(
+				std::move(gfxs),
+				C4HudBarsDef::Bars
+				{
+					C4HudBarDef{"Energy", file, gfx, 0, C4HudBarDef::EBP_Energy},
+					C4HudBarDef{"Magic",  file, gfx, 1, C4HudBarDef::EBP_Magic},
+					C4HudBarDef{"Breath", file, gfx, 2, C4HudBarDef::EBP_Breath}
+				}
+			)
+		);
+		defaultBars = Instantiate(def);
+	}
+
+	return defaultBars;
+}
+
+std::shared_ptr<C4FacetExID> C4HudBarsUniquifier::GetFacet(const std::function<void(StdStrBuf)> &error, const C4HudBarsDef::Gfxs &gfxs, std::string_view gfx)
+{
+	const std::string key{gfx};
+
+	try
+	{
+		const auto facet = graphics.at(key).lock();
+		if (facet) return facet;
+	}
+	catch (const std::out_of_range &)
+	{
+		// handled by code below
+	}
+
+	// facet needs to be loaded
+	std::int32_t amount = 0;
+	std::int32_t scale  = 100;
+	std::string file;
+
+	try
+	{
+		const auto &gfx = gfxs.at(key);
+		amount = gfx.amount;
+		scale = gfx.scale;
+		file = gfx.file;
+	}
+	catch (const std::out_of_range &)
+	{
+		error(FormatString("missing key \"%s\" in graphics definition", key.c_str()));
+		return nullptr;
+	}
+
+	Game.GraphicsResource.RegisterGlobalGraphics();
+	Game.GraphicsResource.RegisterMainGroups();
+
+	const auto deleter = [this, key](C4FacetExID *facet)
+	{
+		graphics.erase(key);
+		delete facet;
+	};
+	const std::shared_ptr<C4FacetExID> facet{new C4FacetExID, deleter};
+	const bool success{Game.GraphicsResource.LoadFile(*facet, file.c_str(), Game.GraphicsResource.Files)};
+	if(!success)
+	{
+		error(FormatString("could not load hud bar graphic \"%s\"", file.c_str()));
+		return nullptr;
+	}
+
+	const std::int32_t barWdt = facet->Surface->Wdt / (amount * 2);
+	const std::int32_t barHgt = facet->Surface->Hgt / 3;
+	const std::int32_t scaledWdt = (barWdt*100) / scale;
+	const std::int32_t scaledHgt = (barHgt*100) / scale;
+	facet->Set(facet->Surface, 0, 0, scaledWdt, scaledHgt);
+
+	graphics.emplace(key, std::weak_ptr<C4FacetExID>{facet});
+	return facet;
+}
+
+std::shared_ptr<const C4HudBarsDef> C4HudBarsUniquifier::UniqueifyDefinition(std::unique_ptr<C4HudBarsDef> definition)
+{
+	// definition always gets owned by a shared_ptr,
+	// that either ends up being the canonical shared_ptr,
+	// or goes out of scope deleting the definition.
+	// the weak ptr remembers the custom deleter
+	const auto deleter = [this](const C4HudBarsDef *def)
+	{
+		definitions.erase(*def);
+		delete def;
+	};
+	const std::shared_ptr<const C4HudBarsDef> shared{definition.release(), deleter};
+	const auto &[it, success] = definitions.emplace(*shared.get(), std::weak_ptr<const C4HudBarsDef>(shared));
+	if (!success)
+	{
+		// definition already existed, create shared ptr from existing weak_ptr
+		return it->second.lock();
+	}
+	return shared;
+}
+
+std::shared_ptr<C4HudBars> C4HudBarsUniquifier::Instantiate(std::shared_ptr<const C4HudBarsDef> definition)
+{
+	if (!definition) return nullptr;
+	return std::make_shared<C4HudBars>(definition);
+}
+
+std::shared_ptr<C4HudBars> C4HudBarsUniquifier::DefineHudBars(C4AulContext *cthr, C4ValueHash &graphics, const C4ValueArray &definition)
+{
+	std::int32_t value_index = 0;
+	C4HudBarsDef::Gfxs gfx;
+	C4HudBarsDef::Bars bars;
+	C4HudBarsDef::Names names;
+
+	ProcessGraphics(cthr, graphics, gfx);
+	ProcessGroup(cthr, value_index, gfx, definition, bars, true);
+	const auto error = [cthr](StdStrBuf msg) { throw C4AulExecError{cthr->Obj, FormatString("DefineHudBars: %s", msg.getData()).getData()}; };
+	C4HudBarsDef::PopulateNamesFromValues(error, bars, names);
+
+	auto def = UniqueifyDefinition(std::move(std::make_unique<C4HudBarsDef>(gfx, bars, names)));
+	return Instantiate(def);
+}
+
+void C4HudBarsUniquifier::ProcessGraphics(C4AulContext *cthr, C4ValueHash &map, C4HudBarsDef::Gfxs &gfx)
+{
+	const auto keyAmount = C4VString("amount");
+	const auto keyScale  = C4VString("scale");
+	const auto keyFile   = C4VString("file");
+
+	for (const auto &[key, val] : map)
+	{
+		if (key.GetType() != C4V_String) {
+			throw C4AulExecError{cthr->Obj, "DefineHudBars: keys within maps are expected to be of type string"};
+		}
+		const auto _key = key.GetRefVal()._getStr()->Data.getData();
+
+		if (val.GetType() != C4V_Map)
+		{
+			throw C4AulExecError{cthr->Obj, FormatString("DefineHudBars: key \"%s\" is not a map, got: %s", _key, val.GetDataString().getData()).getData()};
+		}
+		const auto &m = *val.GetRefVal()._getMap();
+
+		C4Value file = m[keyFile];
+		const auto _file = file ? file.getStr()->Data.getData() : _key;
+
+		// TODO: Check Type and const?
+		auto _amount = m[keyAmount];
+		auto _scale  = m[keyScale];
+		std::int32_t amount = _amount.getInt();
+		std::int32_t scale  = _scale.getInt();
+		if (amount == 0) amount = 1;
+		if (scale == 0) scale = 100;
+
+		if (const auto success = gfx.emplace(_key, C4HudBarsDef::Gfx{_key, _file, amount, scale}).second; !success)
+		{
+			throw C4AulExecError{cthr->Obj, FormatString("DefineHudBars: duplicate key \"%s\" in gfx description ", _key).getData()};
+		}
+	}
+}
+
+void C4HudBarsUniquifier::ProcessGroup(C4AulContext *cthr, std::int32_t &value_index, const C4HudBarsDef::Gfxs &graphics, const C4ValueArray &group, C4HudBarsDef::Bars &bars, bool advanceAlways)
+{
+	const auto error = [cthr](const char *msg, const C4Value &val) {
+		auto format = std::string{"DefineHudBars: "} + msg;
+		throw C4AulExecError{cthr->Obj, FormatString(format.c_str(), val.GetDataString().getData()).getData()};
+	};
+
+	const std::int32_t size{group.GetSize()};
+	for (std::int32_t i = 0; i < size; ++i)
+	{
+		const auto &element = group[i];
+		switch (element.GetType())
+		{
+		case C4V_Map:
+			if (const auto *map = element._getMap(); map)
+			{
+				ProcessHudBar(cthr, value_index, graphics, *map, bars, advanceAlways || i == size-1);
+			}
+			else
+			{
+				error("got unexpected value: %s", element);
+			}
+			break;
+		case C4V_Array:
+			if(advanceAlways)
+			{
+				if (const auto *array = element._getArray(); array)
+				{
+					ProcessGroup(cthr, value_index, graphics, *array, bars, false);
+				}
+				else
+				{
+					error("got unexpected value: %s", element);
+				}
+			}
+			else
+			{
+				error("groups in groups are not allowed: %s", element);
+			}
+			break;
+
+		default:
+			error("array or map expected, got: %s", element);
+		}
+	}
+}
+
+void C4HudBarsUniquifier::ProcessHudBar(C4AulContext *cthr, std::int32_t &value_index, const C4HudBarsDef::Gfxs &graphics, const C4ValueHash &bar, C4HudBarsDef::Bars &bars, bool advance)
+{
+	auto name = bar[C4VString("name")];
+	const auto *_name = name.getStr();
+	if (!_name)
+	{
+		throw C4AulExecError{cthr->Obj, FormatString("DefineHudBars: HudBar definition has invalid name, got: %s", name.GetDataString().getData()).getData()};
+	}
+
+	const auto error = [cthr, _name](const char *property, C4Value &val)
+	{
+		auto format = std::string{"DefineHudBars: \"%s\" definition has invalid "} + property + ", got %s";
+		throw C4AulExecError{cthr->Obj, FormatString(format.c_str(), _name->Data.getData(), val.GetDataString().getData()).getData()};
+	};
+
+	C4Value gfx = bar[C4VString("gfx")];
+	const auto *_gfx = gfx.getStr();
+	if (!_gfx) error("gfx", gfx);
+
+	C4Value physical = bar[C4VString("physical")];
+	auto _physical = static_cast<C4HudBarDef::Physical>(physical.getInt());
+	if (_physical & ~C4HudBarDef::EBP_All) error("physical", physical);
+
+	C4Value hide = bar[C4VString("hide")];
+	auto _hide = C4HudBarDef::EBH_Empty;
+	if (hide) _hide = static_cast<C4HudBarDef::Hide>(hide.getInt());
+	if (_hide & ~C4HudBarDef::EBH_All) error("hide", hide);
+
+	C4Value index = bar[C4VString("index")];
+	C4Value value = bar[C4VString("value")];
+	const auto _index = index.getInt();
+	const auto _value = value.getInt();
+	if (_index < 0) error("index", index);
+	if (_value < 0) error("value", value);
+
+	C4ValueInt _max{1000000};
+	if (bar.contains(C4VString("max")))
+	{
+		auto max = bar[C4VString("max")];
+		_max = max.getInt();
+		if (_max < 0) error("max", max);
+	}
+
+	bool _visible{true};
+	if (bar.contains(C4VString("visible")))
+	{
+		auto visible = bar[C4VString("visible")];
+		_visible = visible.getBool();
+	}
+
+	{
+		const auto file = _gfx->Data.getData();
+		const auto facetError = [cthr, _name](StdStrBuf msg)
+		{
+			throw C4AulExecError{cthr->Obj, FormatString("DefineHudBars: HudBar \"%s\" %s", _name->Data.getData(), msg.getData()).getData()};
+		};
+		const auto facet = GetFacet(facetError, graphics, file);
+
+		C4HudBarDef bar{_name->Data.getData(), file, facet, _index, _physical};
+		if (physical)
+		{
+			bar.physical = _physical;
+			bar.hide = C4HudBarDef::DefaultHide(_physical);
+		}
+		else
+		{
+			bar.value_index = value_index++;
+		}
+		if (hide) bar.hide = _hide;
+		bar.value = _value;
+		bar.max = _max;
+		bar.visible = _visible;
+		bar.advance = advance;
+		auto scale = graphics.at(file).scale;
+		bar.scale = static_cast<float>(scale) / 100.0f;
+		bars.push_back(bar);
+	}
+}
+
+
+void C4HudBarsAdapt::CompileFunc(StdCompiler *comp)
+{
+	if (!comp->isCompiler())
+	{
+		if (bars)
+		{
+			std::vector<C4HudBarsDef::Gfx> temp;
+			for (const auto it : bars->def->gfxs)
+				temp.emplace_back(it.second);
+
+			comp->Value(mkNamingAdapt(mkSTLContainerAdapt(temp), "Gfx", std::vector<C4HudBarsDef::Gfx>{}));
+
+			comp->Value(mkNamingAdapt(mkSTLContainerAdapt(const_cast<std::vector<C4HudBarDef> &>(bars->def->bars)), "Def", C4HudBarsDef::Bars{}));
+			comp->Value(mkNamingAdapt(mkSTLContainerAdapt(bars->values), "Bar", std::vector<C4HudBar>{}));
+		}
+	}
+	else
+	{
+		C4HudBarsDef::Gfxs gfxs_;
+		std::vector<C4HudBarsDef::Gfx> temp;
+		comp->Value(mkNamingAdapt(mkSTLContainerAdapt(temp), "Gfx", std::vector<C4HudBarsDef::Gfx>{}));
+		for (const auto &gfx : temp)
+			gfxs_.emplace(gfx.key, gfx);
+
+		C4HudBarsDef::Bars bars_;
+		comp->Value(mkNamingAdapt(mkSTLContainerAdapt(bars_), "Def", C4HudBarsDef::Bars{}));
+
+		auto def = std::make_unique<C4HudBarsDef>(std::move(gfxs_), std::move(bars_));
+
+		// get facets and restore scale from gfxs
+		const auto facetError = [comp](StdStrBuf msg) { comp->Warn("Error loading HudBars %s", msg.getData()); };
+		for (auto &bar : def->bars)
+		{
+			bar.facet = Game.HudBars.GetFacet(facetError, def->gfxs, bar.gfx.c_str());
+			if (!bar.facet)
+			{
+				bars = Game.HudBars.DefaultBars();
+				return;
+			}
+			bar.scale = static_cast<float>(def->gfxs.at(bar.gfx).scale) / 100.0f;
+		}
+
+		const auto uniq_def = Game.HudBars.UniqueifyDefinition(std::move(def));
+		const auto instance = Game.HudBars.Instantiate(uniq_def);
+		comp->Value(mkNamingAdapt(mkSTLContainerAdapt(instance->values), "Bar", std::vector<C4HudBar>{}));
+
+		bars = instance;
+	}
+}

--- a/src/C4HudBars.cpp
+++ b/src/C4HudBars.cpp
@@ -569,7 +569,7 @@ void C4HudBarsUniquifier::ProcessHudBar(C4AulContext *cthr, std::int32_t &value_
 
 	C4Value physical = bar[C4VString("physical")];
 	auto _physical = static_cast<C4HudBarDef::Physical>(physical.getInt());
-	if (_physical & ~C4HudBarDef::EBP_All) error("physical", physical);
+	if (C4HudBarDef::EBP_First <= _physical && _physical <= C4HudBarDef::EBP_Last) error("physical", physical);
 
 	C4Value hide = bar[C4VString("hide")];
 	auto _hide = C4HudBarDef::EBH_Empty;

--- a/src/C4HudBars.h
+++ b/src/C4HudBars.h
@@ -1,0 +1,203 @@
+/*
+ * LegacyClonk
+ *
+ * Copyright (c) 2021, The LegacyClonk Team and contributors
+ *
+ * Distributed under the terms of the ISC license; see accompanying file
+ * "COPYING" for details.
+ *
+ * "Clonk" is a registered trademark of Matthes Bender, used with permission.
+ * See accompanying file "TRADEMARK" for details.
+ *
+ * To redistribute this file separately, substitute the full license texts
+ * for the above references.
+ */
+
+/* Allows to define custom energy bars */
+
+#pragma once
+
+#include "C4FacetEx.h"
+#include "C4Id.h"
+#include "C4Value.h"
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct C4AulContext;
+class C4Object;
+
+class C4HudBarDef
+{
+public:
+	enum Physical {
+		EBP_None   = 0,
+		EBP_Energy = 1,
+		EBP_Magic  = 2,
+		EBP_Breath = 3,
+		EBP_All = EBP_Energy | EBP_Magic | EBP_Breath
+	};
+	enum Hide {
+		EBH_Never = 0,
+		EBH_HideHUDBars = 0x1, // according to C4Def::HideHUDBars; otherwise HideHUDBars is ignored
+		EBH_Empty = 0x2,
+		EBH_Full = 0x4,
+		EBH_EmptyFull = EBH_Empty | EBH_Full,
+		EBH_All = EBH_EmptyFull | EBH_HideHUDBars
+	};
+
+public:
+	C4HudBarDef() noexcept;
+	C4HudBarDef(std::string_view name, std::string_view file, const std::shared_ptr<C4FacetExID> &gfx, std::int32_t index, Physical physical = EBP_None);
+
+	bool operator==(const C4HudBarDef &rhs) const noexcept;
+
+	static Hide DefaultHide(Physical physical) noexcept;
+	static std::int32_t DefaultIndex(Physical physical) noexcept;
+
+	std::size_t GetHash() const noexcept;
+	void CompileFunc(StdCompiler *comp);
+
+public:
+	std::string name;
+	Physical physical;
+	Hide hide;
+
+	std::string gfx;
+	std::shared_ptr<C4FacetExID> facet; // calculated from gfx
+	std::int32_t index;
+	bool advance;
+
+	std::int32_t value_index;
+	std::int32_t value;
+	std::int32_t max;
+	bool visible;
+	float scale; // calculated from gfx.scale
+};
+
+constexpr C4HudBarDef::Hide operator|(const C4HudBarDef::Hide a, const C4HudBarDef::Hide b) noexcept
+{
+	using und_t = std::underlying_type_t<C4HudBarDef::Hide>;
+	return static_cast<C4HudBarDef::Hide>(static_cast<und_t>(a) | static_cast<und_t>(b));
+}
+
+class C4HudBarsDef
+{
+public:
+	struct Gfx {
+		std::string key;
+		std::string file;
+		std::int32_t amount;
+		std::int32_t scale;
+		Gfx() noexcept;
+		Gfx(std::string key, std::string file, std::int32_t amount, std::int32_t scale) noexcept;
+		bool operator==(const Gfx &rhs) const noexcept;
+
+		void CompileFunc(StdCompiler *comp);
+	};
+	using Gfxs  = std::map<std::string, Gfx>;
+	using Bars  = std::vector<C4HudBarDef>;
+	using Names = std::unordered_map<std::string, std::int32_t>;
+
+	C4HudBarsDef() = default;
+	C4HudBarsDef(Gfxs &&gfxs, Bars &&bars);
+	C4HudBarsDef(const Gfxs &gfxs, const Bars &bars, const Names &names);
+
+	C4HudBarsDef(const C4HudBarsDef &other) = default;
+	C4HudBarsDef(C4HudBarsDef &&other) = default;
+	C4HudBarsDef &operator=(const C4HudBarsDef &other) = default;
+	C4HudBarsDef &operator=(C4HudBarsDef &&other) = default;
+
+	static void PopulateNamesFromValues(const std::function<void(StdStrBuf)> &error, const Bars &bars, Names &names);
+
+	bool operator==(const C4HudBarsDef &rhs) const noexcept;
+	std::size_t GetHash() const noexcept;
+
+public:
+	// the definiton is processed and flattened into a vector of energy bar values
+	// they contain everything needed to draw the energy bars
+	Gfxs  gfxs;
+	Bars  bars;
+	Names names;
+};
+
+class C4HudBar
+{
+public:
+	std::int32_t value;
+	std::int32_t max;
+	bool visible;
+
+	C4HudBar() noexcept;
+	C4HudBar(std::int32_t value, std::int32_t max, bool visible) noexcept;
+	bool operator==(const C4HudBar &rhs) const noexcept;
+
+	void CompileFunc(StdCompiler *comp);
+};
+
+class C4HudBars
+{
+public:
+	std::shared_ptr<const C4HudBarsDef> def;
+	std::vector<C4HudBar> values;
+
+	C4HudBars(std::shared_ptr<const C4HudBarsDef> def) noexcept;
+
+	void DrawHudBars(C4Facet &cgo, C4Object &obj) const noexcept;
+	void SetHudBarValue(C4AulContext *cthr, const std::string &name, std::int32_t value, std::int32_t max = 0);
+	void SetHudBarVisibility(C4AulContext *cthr, const std::string &name, bool visible);
+
+private:
+	C4HudBar *BarVal(C4AulContext *cthr, const char *functionName, const std::string &name);
+};
+
+namespace std
+{
+	template<>
+	struct hash<const C4HudBarsDef>
+	{
+		std::size_t operator()(const C4HudBarsDef &value) const noexcept;
+	};
+}
+
+class C4HudBarsUniquifier
+{
+public:
+	std::shared_ptr<C4HudBars>          DefaultBars();
+	std::shared_ptr<C4FacetExID>        GetFacet(const std::function<void(StdStrBuf)> &error, const C4HudBarsDef::Gfxs &gfx, std::string_view file);
+	std::shared_ptr<const C4HudBarsDef> UniqueifyDefinition(std::unique_ptr<C4HudBarsDef> definition);
+	std::shared_ptr<C4HudBars>          Instantiate(std::shared_ptr<const C4HudBarsDef> definition);
+	std::shared_ptr<C4HudBars>          DefineHudBars(C4AulContext *cthr, C4ValueHash &graphics, const C4ValueArray &definition);
+
+private:
+	void ProcessGraphics(C4AulContext *cthr, C4ValueHash &map, C4HudBarsDef::Gfxs &gfx);
+	void ProcessGroup(C4AulContext *cthr, std::int32_t &value_index, const C4HudBarsDef::Gfxs &graphics, const C4ValueArray &group, C4HudBarsDef::Bars &bars, bool advanceAlways);
+	void ProcessHudBar(C4AulContext *cthr, std::int32_t &value_index, const C4HudBarsDef::Gfxs &graphics, const C4ValueHash &bar, C4HudBarsDef::Bars &bars, bool advance);
+
+  using C4HudBarsDefRef = std::reference_wrapper<const C4HudBarsDef>;
+  using Definitions = std::unordered_map<C4HudBarsDefRef, std::weak_ptr<const C4HudBarsDef>, std::hash<const C4HudBarsDef>, std::equal_to<const C4HudBarsDef>>;
+
+	std::unordered_map<std::string, std::weak_ptr<C4FacetExID>> graphics;
+	Definitions definitions;
+
+	std::shared_ptr<C4HudBars> defaultBars;
+};
+
+
+class C4HudBarsAdapt
+{
+protected:
+	std::shared_ptr<C4HudBars> &bars;
+
+public:
+	C4HudBarsAdapt(std::shared_ptr<C4HudBars> &bars) : bars{bars} {}
+	void CompileFunc(StdCompiler *comp);
+
+	// Default checking / setting
+	bool operator==(std::shared_ptr<C4HudBars> pDefault) { return bars == pDefault; }
+	void operator=(std::shared_ptr<C4HudBars> pDefault)  { bars = pDefault; }
+};

--- a/src/C4HudBars.h
+++ b/src/C4HudBars.h
@@ -39,7 +39,8 @@ public:
 		EBP_Energy = 1,
 		EBP_Magic  = 2,
 		EBP_Breath = 3,
-		EBP_All = EBP_Energy | EBP_Magic | EBP_Breath
+		EBP_First = EBP_None,
+		EBP_Last = EBP_Breath
 	};
 	enum Hide {
 		EBH_Never = 0,

--- a/src/C4Object.h
+++ b/src/C4Object.h
@@ -20,6 +20,7 @@
 
 #include "C4Command.h"
 #include "C4Effects.h"
+#include "C4HudBars.h"
 #include "C4EnumeratedObjectPtr.h"
 #include "C4Facet.h"
 #include "C4Id.h"
@@ -198,6 +199,8 @@ public:
 
 	class C4GraphicsOverlay *pGfxOverlay; // singly linked list of overlay graphics
 
+	std::shared_ptr<C4HudBars> hudBars;
+
 protected:
 	std::string CustomName;
 	bool OnFire;
@@ -254,9 +257,12 @@ public:
 		int32_t nx, int32_t ny, int32_t nr,
 		FIXED nxdir, FIXED nydir, FIXED nrdir, int32_t iController);
 	void CompileFunc(StdCompiler *pComp);
-	void DrawEnergy(C4Facet &cgo);
-	void DrawMagicEnergy(C4Facet &cgo);
-	void DrawBreath(C4Facet &cgo);
+
+	bool DefineHudBars(C4AulContext *cthr, C4ValueHash *graphics, C4ValueArray *definition);
+	void SetHudBarValue(C4AulContext *cthr, const char *name, int32_t value, int32_t max = 0);
+	void SetHudBarVisibility(C4AulContext *cthr, const char *name, bool fVisible);
+	void DrawHudBars(C4Facet &cgo);
+
 	void DrawLine(C4FacetEx &cgo);
 	void DrawCommands(C4Facet &cgo, C4Facet &cgo2, C4RegionList *pRegions);
 	void DrawCommand(C4Facet &cgoBar, int32_t iAlign, const char *szFunctionFormat,

--- a/src/C4Script.cpp
+++ b/src/C4Script.cpp
@@ -24,6 +24,7 @@
 #include <C4Version.h>
 
 #include <C4Application.h>
+#include <C4HudBars.h>
 #include <C4Object.h>
 #include <C4ObjectInfo.h>
 #include <C4ObjectCom.h>
@@ -1722,6 +1723,29 @@ static bool FnSetMenuTextProgress(C4AulContext *cthr, C4ValueInt iNewProgress, C
 {
 	if (!pMenuObj || !pMenuObj->Menu) return false;
 	return pMenuObj->Menu->SetTextProgress(iNewProgress, false);
+}
+
+// Custom Energy Bars
+
+static bool FnDefineHudBars(C4AulContext *cthr, C4ValueHash *graphics, C4ValueArray *bars)
+{
+	const auto obj = cthr->Obj;
+	if (!obj) return false;
+	return obj->DefineHudBars(cthr, graphics, bars);
+}
+
+static void FnSetHudBarValue(C4AulContext *cthr, C4String *name, C4ValueInt newValue, C4ValueInt newMax)
+{
+	const auto obj = cthr->Obj;
+	if (!obj) return;
+	obj->SetHudBarValue(cthr, FnStringPar(name), newValue, newMax);
+}
+
+static void FnSetHudBarVisibility(C4AulContext *cthr, C4String *name, bool visible)
+{
+	const auto obj = cthr->Obj;
+	if (!obj) return;
+	obj->SetHudBarVisibility(cthr, FnStringPar(name), visible);
 }
 
 // Check / Status
@@ -6296,6 +6320,15 @@ static constexpr C4ScriptConstDef C4ScriptConstMap[] =
 	{ "C4MN_Add_ForceCount",  C4V_Int, C4MN_Add_ForceCount },
 	{ "C4MN_Add_ForceNoDesc", C4V_Int, C4MN_Add_ForceNoDesc },
 
+	{ "EBP_None",        C4V_Int, C4HudBarDef::EBP_None },
+	{ "EBP_Energy",      C4V_Int, C4HudBarDef::EBP_Energy },
+	{ "EBP_Magic",       C4V_Int, C4HudBarDef::EBP_Magic },
+	{ "EBP_Breath",      C4V_Int, C4HudBarDef::EBP_Breath },
+	{ "EBH_Never",       C4V_Int, C4HudBarDef::EBH_Never },
+	{ "EBH_Empty",       C4V_Int, C4HudBarDef::EBH_Empty },
+	{ "EBH_Full",        C4V_Int, C4HudBarDef::EBH_Full },
+	{ "EBH_HideHUDBars", C4V_Int, C4HudBarDef::EBH_HideHUDBars },
+
 	{ "FX_OK",                  C4V_Int, C4Fx_OK }, // generic standard behaviour for all effect callbacks
 	{ "FX_Effect_Deny",         C4V_Int, C4Fx_Effect_Deny }, // delete effect
 	{ "FX_Effect_Annul",        C4V_Int, C4Fx_Effect_Annul }, // delete effect, because it has annulled a countereffect
@@ -6813,6 +6846,9 @@ void InitFunctionMap(C4AulScriptEngine *pEngine)
 	AddFunc(pEngine, "SelectMenuItem",                  FnSelectMenuItem);
 	AddFunc(pEngine, "SetMenuDecoration",               FnSetMenuDecoration);
 	AddFunc(pEngine, "SetMenuTextProgress",             FnSetMenuTextProgress);
+	AddFunc(pEngine, "DefineHudBars",                   FnDefineHudBars);
+	AddFunc(pEngine, "SetHudBarValue",                  FnSetHudBarValue);
+	AddFunc(pEngine, "SetHudBarVisibility",             FnSetHudBarVisibility);
 	AddFunc(pEngine, "SetSeason",                       FnSetSeason);
 	AddFunc(pEngine, "GetSeason",                       FnGetSeason);
 	AddFunc(pEngine, "SetClimate",                      FnSetClimate);

--- a/src/C4Viewport.cpp
+++ b/src/C4Viewport.cpp
@@ -938,24 +938,12 @@ void C4Viewport::DrawCursorInfo(C4FacetEx &cgo)
 		{
 			int32_t cx = C4SymbolBorder;
 			C4ST_STARTNEW(EnStat, "C4Viewport::DrawCursorInfo: Energy")
-			int32_t bar_wdt = Game.GraphicsResource.fctEnergyBars.Wdt;
 			int32_t iYOff = Config.Graphics.ShowPortraits ? 10 : 0;
-			// Energy
-			ccgo.Set(cgo.Surface, cgo.X + cx, cgo.Y + C4SymbolSize + 2 * C4SymbolBorder + iYOff, bar_wdt, cgo.Hgt - 3 * C4SymbolBorder - 2 * C4SymbolSize - iYOff);
-			if (!(cursor->Def->HideHUDBars & C4DefCore::HB_Energy))
-			{
-				cursor->DrawEnergy(ccgo); ccgo.X += bar_wdt + 1;
-			}
-			// Magic energy
-			if (cursor->MagicEnergy && !(cursor->Def->HideHUDBars & C4DefCore::HB_MagicEnergy))
-			{
-				cursor->DrawMagicEnergy(ccgo); ccgo.X += bar_wdt + 1;
-			}
-			// Breath
-			if (cursor->Breath && (cursor->Breath < cursor->GetPhysical()->Breath) && !(cursor->Def->HideHUDBars & C4DefCore::HB_Breath))
-			{
-				cursor->DrawBreath(ccgo); ccgo.X += bar_wdt + 1;
-			}
+
+			ccgo.Set(cgo.Surface, cgo.X + cx, cgo.Y + C4SymbolSize + 2 * C4SymbolBorder + iYOff, 0, cgo.Hgt - 3 * C4SymbolBorder - 2 * C4SymbolSize - iYOff);
+
+			cursor->DrawHudBars(ccgo);
+
 			C4ST_STOP(EnStat)
 		}
 

--- a/src/StdHelpers.h
+++ b/src/StdHelpers.h
@@ -20,3 +20,43 @@ public:
 	StdOverloadedCallable(T... bases) : T{bases}... {}
 	using T::operator()...;
 };
+
+// based on boost container_hash's hashCombine
+constexpr void HashCombine(std::size_t &hash, std::size_t nextHash)
+{
+	if constexpr (sizeof(std::size_t) == 4)
+	{
+#define rotateLeft32(x, r) (x << r) | (x >> (32 - r))
+		constexpr std::size_t c1 = 0xcc9e2d51;
+		constexpr std::size_t c2 = 0x1b873593;
+
+		nextHash *= c1;
+		nextHash = rotateLeft32(nextHash, 15);
+		nextHash *= c2;
+
+		hash ^= nextHash;
+		hash = rotateLeft32(hash, 13);
+		hash = hash * 5 + 0xe6546b64;
+#undef rotateLeft32
+	}
+	else if constexpr (sizeof(std::size_t) == 8)
+	{
+		constexpr std::size_t m = 0xc6a4a7935bd1e995;
+		constexpr int r = 47;
+
+		nextHash *= m;
+		nextHash ^= nextHash >> r;
+		nextHash *= m;
+
+		hash ^= nextHash;
+		hash *= m;
+
+		// Completely arbitrary number, to prevent 0's
+		// from hashing to 0.
+		hash += 0xe6546b64;
+	}
+	else
+	{
+		hash ^= nextHash + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	}
+}


### PR DESCRIPTION
This branch adds support for custom energy bars.
The bars can be defined at runtime via script calls, the graphics have to be part of a graphics.c4g folder.
The custom energy bar code was unified with the old default/builtin energy bar code.

Script Example:
```
DefineEnergyBars({S = {file = "SEnergyBars", amount = 5, scale = 200}},[
  {name = "Energy", gfx = "S", index = 0, physical = EBP_Energy},
//  {name = "Magic",  gfx = "S", index = 1, physical = EBP_Magic},
  {name = "Slime",  gfx = "S", index = 3, physical = EBP_Magic,  hide = EBH_Empty},
  {name = "Goop",   gfx = "S", index = 4, value = 30, max = 100, visible = false, hide = EBH_Empty},
  {name = "Breath", gfx = "S", index = 2, physical = EBP_Breath}
]);
SetEnergyBar("Goop", 50, /*optional*/ new_max, /*optional*/ object); // (only for non-physical-based bars)
SetEnergyBarVisible("Goop", true, /*optional*/ object); // manual visibility control via script (only for non-physical-based bars)  
```
All objects share the default energy bar definition & empty instance (because default is based on physicals), until some script defines a custom energy bar definition via `DefineEnergyBars` this assigns a different energybars instance to the target object.
Definitions which are equal are uniquified and shared between multiple objects using the same definition.
Graphics are also loaded once and shared.

The default energy bars result in no de-/serializiation (CompileFunc).
CustomEnergyBars are stored like this:
```
[Object]
id=SLCK
Number=8
Info=Heimdall
...

  [EnergyBars]

    [Gfx]
    Key="S"
    File="SEnergyBars"
    Amount=5
    Scale=200

    [Def]
    Name="Energy"
    Physical=1
    Hide=512
    Gfx="S"
    Index=0
    Max=0

    [Def]
    Name="Slime"
    Physical=2
    Gfx="S"
    Index=3
    Max=0

    [Def]
    Name="Goop"
    Gfx="S"
    Index=4
    ValueIndex=0
    Value=30
    Max=100
    Visible=false

    [Def]
    Name="Breath"
    Physical=3
    Hide=515
    Gfx="S"
    Index=2
    Max=0

    [Bar]
    Value=30
    Max=100
    Visible=false
```
EnergyBars can be completely replaced by new bars, or used in combination with default bars.
It is also possible to just adjust the graphics while keeping the default behavior. (based on physicals)
An additional feature is, that it is possible to place energy bars above another by grouping them within an array,
this can be used to draw e.g. a transparent shield bar layered above the health bar.
(You can't have groups within groups, because its unclear whether it would be useful)

In general I would like some feedback from others familiar with the codebase.
This is work in progress, I could use some new perspectives on the code / things that I might have missed, then eventually I could do a rebase and clean the branch up a little bit more. Let me know your thoughts.

Simon

## TODOs:
 - [x] share hashCombine between C4EnergyBars.cpp and C4Value.cpp where it was copied from
 - [x] ~~investigate why the call to Game.GraphicsResource.RegisterMainGroups(); is needed~~ -> reasoning below
 - [x] code style? is there a guide?
 - [x] verify with debugger or other tools that shared_ptr with custom deleters work as expected ~~? any tips?~~ https://github.com/SimonLSchlee/LegacyClonk/commit/722c0ed901d9a057f86ab76361eccf008b64580e#commitcomment-57746799
 
### RegisterMainGroups / RegisterGlobalGraphics
The code currently explicitly calls RegisterMainGroups and RegisterGlobalGraphics, it simply is what works so that the graphics you would expect to be loadable are actually loaded. I am unsure what exactly the reason is, why things aren't already setup to work that way else where, and it irks me somewhat, but I don't have a clear answer to that without reading a lot of code. And at the end the answer might simply be "it was done that way" instead of a more satisfying "it was designed this way for reason x to do y". I don't know the intent of some things in the code base, thus I opt with keeping it minimal using what works and if there is a better way to do it, it will be found over time or maybe someone can point it out. I stopped investigating those calls and more generally C4Group stuff, because I am not sure that it would be useful and efficient use of my time, that's mainly why abort that for now. I don't want to keep TODOs open which aren't connected to clear action steps.