### PR TITLE
Increasing max picture size for player icons.

### DIFF
--- a/src/C4Constants.h
+++ b/src/C4Constants.h
@@ -76,8 +76,8 @@ const int C4SymbolSize = 35,
           C4SymbolBorder = 5,
           C4UpperBoardHeight = 50,
           C4PictureSize = 64,
-          C4MaxPictureSize = 150,
-          C4MaxBigIconSize = 64;
+          C4MaxPictureSize = 450,
+          C4MaxBigIconSize = 200;
 
 const int C4P_MaxPosition = 4;
 

--- a/src/C4Network2Res.cpp
+++ b/src/C4Network2Res.cpp
@@ -1188,7 +1188,10 @@ bool C4Network2Res::OptimizeStandalone(bool fSilent)
 		size_t iBigIconSize = 0;
 		if (Grp.FindEntry(C4CFN_BigIcon, nullptr, &iBigIconSize))
 			if (iBigIconSize > C4NetResMaxBigicon * 1024)
-				Grp.Delete(C4CFN_BigIcon);
+            {
+                Grp.Delete(C4CFN_BigIcon);
+                LogF("OptimizeStandalone: BigIcon is too large! Maximum allowed file size is %" PRId32 " Kibibytes. Deleting BigIcon.png for distribution of the player file in network.", C4NetResMaxBigicon);
+            }
 		Grp.Close();
 	}
 	return true;

--- a/src/C4Network2Res.h
+++ b/src/C4Network2Res.h
@@ -32,7 +32,7 @@ const int32_t C4NetResDiscoverTimeout = 10, // (s)
               C4NetResMaxLoad = 20,
               C4NetResLoadTimeout = 60, // (s)
               C4NetResDeleteTime = 60, // (s)
-              C4NetResMaxBigicon = 20; // maximum size, in KB, of bigicon
+              C4NetResMaxBigicon = 100; // maximum size, in KB, of bigicon
 
 const int32_t C4NetResIDAnonymous = -2;
 


### PR DESCRIPTION
- Size of Picture.png increased to ~~900px~~ 450px max as the file is only used locally and has no effect on resource loading over the network.
- Size of BigIcon.png increased to 200px max for screens with higher resolution (means higher scaling ingame).
- Log entry is now written when BigIcon is too large and removed for network games.

Due to the resize of BigIcon.png the maximum filesize for BigIcon was raised from 20 to 100 Kibibytes. Testing the limit with converting a noisy flower meadow (1200 * 901px @ 2 MBytes original, set as profile picture), BigIcon size was about 65 KBytes.