### PR TITLE
StdGL: Move gamma calculation to shaders if shaders are enabled

### DIFF
--- a/src/C4Config.cpp
+++ b/src/C4Config.cpp
@@ -205,6 +205,7 @@ void C4ConfigGraphics::CompileFunc(StdCompiler *pComp)
 #endif
 
 	pComp->Value(mkNamingAdapt(ShowFolderMaps, "ShowFolderMaps", true));
+	pComp->Value(mkNamingAdapt(UseShaderGamma, "UseShaderGamma", true));
 }
 
 void C4ConfigSound::CompileFunc(StdCompiler *pComp)

--- a/src/C4Config.h
+++ b/src/C4Config.h
@@ -169,6 +169,7 @@ public:
 	int PositionY;
 #endif
 	bool ShowFolderMaps; // if true, folder maps are shown
+	bool UseShaderGamma; // whether to use shader-based gamma correction
 
 	void CompileFunc(StdCompiler *pComp);
 };

--- a/src/C4Game.cpp
+++ b/src/C4Game.cpp
@@ -2099,7 +2099,7 @@ bool C4Game::SaveGameTitle(C4Group &hGroup)
 			0.0f, 0.0f, float(Application.DDraw->lpBack->Wdt), float(Application.DDraw->lpBack->Hgt),
 			surface.get(), 0, 0, surfaceWidth, surfaceHeight);
 
-		if (!surface->SavePNG(Config.AtTempPath(C4CFN_TempTitle), false, true, false))
+		if (!surface->SavePNG(Config.AtTempPath(C4CFN_TempTitle), false, !Config.Graphics.Shader, false))
 		{
 			return false;
 		}

--- a/src/C4GraphicsSystem.cpp
+++ b/src/C4GraphicsSystem.cpp
@@ -574,7 +574,10 @@ bool C4GraphicsSystem::DoSaveScreenshot(bool fSaveAll, const char *szFilename)
 				// transfer each pixel - slooow...
 				for (int32_t iY2 = 0; iY2 < bkHgt2; ++iY2)
 					for (int32_t iX2 = 0; iX2 < bkWdt2; ++iX2)
-						bmp.SetPixel24(iRealX + iX2, iRealY + iY2, Application.DDraw->ApplyGammaTo(Application.DDraw->lpBack->GetPixDw(iX2, iY2, false, scale)));
+					{
+						const std::uint32_t pixel{Application.DDraw->lpBack->GetPixDw(iX2, iY2, false, scale)};
+						bmp.SetPixel24(iRealX + iX2, iRealY + iY2, Config.Graphics.Shader ? pixel : Application.DDraw->ApplyGammaTo(pixel));
+					}
 				// done; unlock
 				Application.DDraw->lpBack->Unlock();
 			}
@@ -597,7 +600,7 @@ bool C4GraphicsSystem::DoSaveScreenshot(bool fSaveAll, const char *szFilename)
 		return true;
 	}
 	// Save primary surface
-	return Application.DDraw->lpBack->SavePNG(szFilename, false, true, false, scale);
+	return Application.DDraw->lpBack->SavePNG(szFilename, false, !Config.Graphics.Shader, false, scale);
 }
 
 void C4GraphicsSystem::DeactivateDebugOutput()

--- a/src/StdDDraw2.h
+++ b/src/StdDDraw2.h
@@ -249,6 +249,7 @@ public:
 	bool AddShader(CStdShader *shader);
 
 	virtual void Link() = 0;
+	virtual void Validate() = 0;
 	void Select();
 	static void Deselect();
 	virtual void Clear();

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -949,7 +949,7 @@ void CStdGL::DisableGamma()
 	{
 		return;
 	}
-	else if (Config.Graphics.Shader)
+	else if (Config.Graphics.Shader && Config.Graphics.UseShaderGamma)
 	{
 		GammaRedTexture.Clear();
 		GammaGreenTexture.Clear();
@@ -975,7 +975,7 @@ void CStdGL::EnableGamma()
 	{
 		return;
 	}
-	else if (Config.Graphics.Shader)
+	else if (Config.Graphics.Shader && Config.Graphics.UseShaderGamma)
 	{
 		assert(GammaRedTexture && GammaGreenTexture && GammaBlueTexture);
 	}
@@ -987,7 +987,7 @@ bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool force)
 {
 	if (Config.Graphics.DisableGamma) return true;
 
-	else if (Config.Graphics.Shader)
+	else if (Config.Graphics.Shader && Config.Graphics.UseShaderGamma)
 	{
 		glActiveTexture(GL_TEXTURE3);
 		GammaRedTexture.UpdateData(ramp.red);
@@ -1004,7 +1004,7 @@ bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool force)
 
 bool CStdGL::SaveDefaultGammaRamp(CStdWindow *window)
 {
-	if (Config.Graphics.Shader || Config.Graphics.DisableGamma)
+	if ((Config.Graphics.Shader && Config.Graphics.UseShaderGamma) || Config.Graphics.DisableGamma)
 	{
 		DefRamp.Default();
 		Gamma.Set(0x000000, 0x808080, 0xffffff, 256, &DefRamp);
@@ -1100,7 +1100,7 @@ bool CStdGL::RestoreDeviceObjects()
 				)"
 			};
 
-			if (!Config.Graphics.DisableGamma)
+			if (Config.Graphics.UseShaderGamma && !Config.Graphics.DisableGamma)
 			{
 				blitFragmentShader.SetMacro("LC_GAMMA", "1");
 			}
@@ -1167,7 +1167,7 @@ bool CStdGL::RestoreDeviceObjects()
 				landscapeFragmentShader.SetMacro("LC_COLOR_ANIMATION", "1");
 			}
 
-			if (!Config.Graphics.DisableGamma)
+			if (Config.Graphics.UseShaderGamma && !Config.Graphics.DisableGamma)
 			{
 				landscapeFragmentShader.SetMacro("LC_GAMMA", "1");
 			}
@@ -1178,7 +1178,7 @@ bool CStdGL::RestoreDeviceObjects()
 			LandscapeShader.AddShader(&landscapeFragmentShader);
 			LandscapeShader.Link();
 
-			if (!Config.Graphics.DisableGamma)
+			if (Config.Graphics.UseShaderGamma && !Config.Graphics.DisableGamma)
 			{
 				CStdGLShader dummyVertexShader{CStdShader::Type::Vertex,
 				R"(
@@ -1225,7 +1225,7 @@ bool CStdGL::RestoreDeviceObjects()
 				program.SetUniform("blitOffset", blitOffset);
 				program.SetUniform("textureSampler", glUniform1i, 0);
 
-				if (!Config.Graphics.DisableGamma)
+				if (Config.Graphics.UseShaderGamma && !Config.Graphics.DisableGamma)
 				{
 					program.SetUniform("gammaRed", glUniform1i, 3);
 					program.SetUniform("gammaGreen", glUniform1i, 4);
@@ -1254,7 +1254,7 @@ bool CStdGL::RestoreDeviceObjects()
 
 			CStdShaderProgram::Deselect();
 
-			if (!Config.Graphics.DisableGamma)
+			if (Config.Graphics.UseShaderGamma && !Config.Graphics.DisableGamma)
 			{
 				const auto createTexture = [this](auto &texture, const std::int32_t offset)
 				{
@@ -1292,7 +1292,7 @@ bool CStdGL::InvalidateDeviceObjects()
 {
 	// clear gamma
 #ifdef USE_SDL_MAINLOOP
-	if (Config.Graphics.Shader)
+	if (Config.Graphics.Shader && Config.Graphics.UseShaderGamma)
 #endif
 		CStdGL::DisableGamma();
 	// deactivate

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -1153,8 +1153,8 @@ bool CStdGL::RestoreDeviceObjects()
 					void main()
 					{
 						gl_FragColor.r = texture2D(gamma, vec2(gl_Color.r, 0)).r;
-						gl_FragColor.g = texture2D(gamma, vec2(gl_Color.g, 0)).r;
-						gl_FragColor.b = texture2D(gamma, vec2(gl_Color.b, 0)).r;
+						gl_FragColor.g = texture2D(gamma, vec2(gl_Color.g, 1)).r;
+						gl_FragColor.b = texture2D(gamma, vec2(gl_Color.b, 2)).r;
 						gl_FragColor.a = gl_Color.a;
 					}
 					)"

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -1203,9 +1203,9 @@ bool CStdGL::RestoreDeviceObjects()
 
 					void main()
 					{
-						gl_FragColor.r = texture1D(gammaRed, gl_FragColor.r).r;
-						gl_FragColor.g = texture1D(gammaGreen, gl_FragColor.g).r;
-						gl_FragColor.b = texture1D(gammaBlue, gl_FragColor.b).r;
+						gl_FragColor.r = texture1D(gammaRed, gl_Color.r).r;
+						gl_FragColor.g = texture1D(gammaGreen, gl_Color.g).r;
+						gl_FragColor.b = texture1D(gammaBlue, gl_Color.b).r;
 						gl_FragColor.a = gl_Color.a;
 					}
 					)"

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -277,6 +277,7 @@ void CStdGLTexture<T, Dimensions>::Clear()
 	if (texture)
 	{
 		glDeleteTextures(1, &texture);
+		texture = GL_NONE;
 	}
 }
 

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -1001,8 +1001,6 @@ bool CStdGL::RestoreDeviceObjects()
 {
 	// safety
 	if (!lpPrimary) return false;
-	// delete any previous objects
-	InvalidateDeviceObjects();
 	// restore primary/back
 	RenderTarget = lpPrimary;
 	lpPrimary->AttachSfc(nullptr);

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -1020,13 +1020,6 @@ bool CStdGL::RestoreDeviceObjects()
 
 	if (Config.Graphics.Shader && !BlitShader)
 	{
-		glEnable(GL_DEBUG_OUTPUT);
-		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-		glDebugMessageCallback([](auto, auto, auto, auto, auto, const GLchar *const message, auto)
-		{
-			LogF("%s", message);
-		}, nullptr);
-
 		try
 		{
 			CStdGLShader vertexShader{CStdShader::Type::Vertex,

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -1200,8 +1200,8 @@ bool CStdGL::RestoreDeviceObjects()
 				GammaTexture = {Gamma.GetSize(), 3, GL_R16, GL_RED, GL_UNSIGNED_SHORT};
 				GammaTexture.Bind(GL_TEXTURE_2D, 3);
 
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -134,6 +134,8 @@ protected:
 template<GLenum T, std::size_t Dimensions>
 class CStdGLTexture
 {
+	static_assert(Dimensions >= 1 && Dimensions <= 3);
+
 public:
 	static constexpr GLenum Target{T};
 
@@ -172,7 +174,7 @@ public:
 
 	void Bind(GLenum offset);
 	void SetData(const void *const data);
-	void UpdateData(const void *const data);
+	void UpdateData(const void *data);
 
 	void Clear();
 
@@ -181,6 +183,8 @@ public:
 
 private:
 	static void ThrowIfGLError();
+	static auto GetSetDataFunction();
+	static auto GetUpdateDataFunction();
 
 private:
 	std::array<std::int32_t, Dimensions> dimensions;

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -131,12 +131,8 @@ protected:
 };
 
 // one OpenGL texture
-template<GLenum T, std::size_t Dimensions>
 class CStdGLTexture
 {
-public:
-	static constexpr GLenum Target{T};
-
 public:
 	class Exception : public CStdRenderException
 	{
@@ -146,8 +142,7 @@ public:
 
 public:
 	CStdGLTexture() = default;
-
-	CStdGLTexture(std::array<std::int32_t, Dimensions> dimensions, GLenum internalFormat, GLenum format, GLenum type);
+	CStdGLTexture(std::int32_t width, std::int32_t height, GLenum internalFormat, GLenum format, GLenum type);
 
 	CStdGLTexture(const CStdGLTexture &) = delete;
 	CStdGLTexture &operator=(const CStdGLTexture &) = delete;
@@ -170,9 +165,9 @@ public:
 public:
 	GLuint GetTexture() const { return texture; }
 
-	void Bind(GLenum offset);
-	void SetData(const void *const data);
-	void UpdateData(const void *const data);
+	void Bind(GLenum target, GLenum offset);
+	void SetData(GLenum target, const void *data);
+	void UpdateData(GLenum target, const void *data);
 
 	void Clear();
 
@@ -183,7 +178,8 @@ private:
 	static void ThrowIfGLError();
 
 private:
-	std::array<std::int32_t, Dimensions> dimensions;
+	std::int32_t width;
+	std::int32_t height;
 	GLenum internalFormat;
 	GLenum format;
 	GLenum type;
@@ -193,7 +189,8 @@ private:
 	friend void swap(CStdGLTexture &first, CStdGLTexture &second)
 	{
 		using std::swap;
-		swap(first.dimensions, second.dimensions);
+		swap(first.width, second.width);
+		swap(first.height, second.height);
 		swap(first.internalFormat, second.internalFormat);
 		swap(first.format, second.format);
 		swap(first.type, second.type);
@@ -258,7 +255,7 @@ protected:
 	CStdGLShaderProgram BlitShaderMod2;
 	CStdGLShaderProgram LandscapeShader;
 	CStdGLShaderProgram DummyShader;
-	CStdGLTexture<GL_TEXTURE_2D, 2> GammaTexture;
+	CStdGLTexture GammaTexture;
 
 public:
 	// General

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -171,6 +171,8 @@ public:
 	void SetData(const void *const data);
 	void UpdateData(const void *const data);
 
+	void Clear();
+
 public:
 	explicit operator bool() const { return texture; }
 
@@ -283,6 +285,8 @@ public:
 	void DrawPixInt(C4Surface *sfcDest, float tx, float ty, uint32_t dwCol) override;
 
 	// Gamma
+	void DisableGamma() override;
+	void EnableGamma() override;
 	virtual bool ApplyGammaRamp(CGammaControl &ramp, bool force) override;
 	virtual bool SaveDefaultGammaRamp(CStdWindow *window) override;
 

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -262,7 +262,9 @@ protected:
 	CStdGLShaderProgram BlitShaderMod2;
 	CStdGLShaderProgram LandscapeShader;
 	CStdGLShaderProgram DummyShader;
-	CStdGLTexture<GL_TEXTURE_2D, 2> GammaTexture;
+	CStdGLTexture<GL_TEXTURE_1D, 1> GammaRedTexture;
+	CStdGLTexture<GL_TEXTURE_1D, 1> GammaGreenTexture;
+	CStdGLTexture<GL_TEXTURE_1D, 1> GammaBlueTexture;
 
 public:
 	// General

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -60,6 +60,7 @@ public:
 	explicit operator bool() const override { return /*glIsProgram(*/shaderProgram/*)*/; }
 
 	void Link() override;
+	void Validate() override;
 	void Clear() override;
 
 	void EnsureProgram() override;
@@ -120,6 +121,9 @@ protected:
 
 		return true;
 	}
+
+private:
+	void CheckStatus(GLenum type);
 
 protected:
 	GLuint shaderProgram{GL_NONE};

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -131,8 +131,12 @@ protected:
 };
 
 // one OpenGL texture
+template<GLenum T, std::size_t Dimensions>
 class CStdGLTexture
 {
+public:
+	static constexpr GLenum Target{T};
+
 public:
 	class Exception : public CStdRenderException
 	{
@@ -142,7 +146,8 @@ public:
 
 public:
 	CStdGLTexture() = default;
-	CStdGLTexture(std::int32_t width, std::int32_t height, GLenum internalFormat, GLenum format, GLenum type);
+
+	CStdGLTexture(std::array<std::int32_t, Dimensions> dimensions, GLenum internalFormat, GLenum format, GLenum type);
 
 	CStdGLTexture(const CStdGLTexture &) = delete;
 	CStdGLTexture &operator=(const CStdGLTexture &) = delete;
@@ -165,9 +170,9 @@ public:
 public:
 	GLuint GetTexture() const { return texture; }
 
-	void Bind(GLenum target, GLenum offset);
-	void SetData(GLenum target, const void *data);
-	void UpdateData(GLenum target, const void *data);
+	void Bind(GLenum offset);
+	void SetData(const void *const data);
+	void UpdateData(const void *const data);
 
 	void Clear();
 
@@ -178,8 +183,7 @@ private:
 	static void ThrowIfGLError();
 
 private:
-	std::int32_t width;
-	std::int32_t height;
+	std::array<std::int32_t, Dimensions> dimensions;
 	GLenum internalFormat;
 	GLenum format;
 	GLenum type;
@@ -189,8 +193,7 @@ private:
 	friend void swap(CStdGLTexture &first, CStdGLTexture &second)
 	{
 		using std::swap;
-		swap(first.width, second.width);
-		swap(first.height, second.height);
+		swap(first.dimensions, second.dimensions);
 		swap(first.internalFormat, second.internalFormat);
 		swap(first.format, second.format);
 		swap(first.type, second.type);
@@ -255,7 +258,7 @@ protected:
 	CStdGLShaderProgram BlitShaderMod2;
 	CStdGLShaderProgram LandscapeShader;
 	CStdGLShaderProgram DummyShader;
-	CStdGLTexture GammaTexture;
+	CStdGLTexture<GL_TEXTURE_2D, 2> GammaTexture;
 
 public:
 	// General

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -136,15 +136,18 @@ class CStdGLTexture
 {
 public:
 	static constexpr GLenum Target{T};
+
+public:
+	class Exception : public CStdRenderException
+	{
+	public:
+		using CStdRenderException::CStdRenderException;
+	};
+
 public:
 	CStdGLTexture() = default;
 
-	CStdGLTexture(std::array<std::int32_t, Dimensions> dimensions, const GLenum internalFormat, const GLenum format, const GLenum type)
-		: dimensions{std::move(dimensions)}, internalFormat{internalFormat}, format{format}, type{type}
-	{
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		glGenTextures(1, &texture);
-	}
+	CStdGLTexture(std::array<std::int32_t, Dimensions> dimensions, GLenum internalFormat, GLenum format, GLenum type);
 
 	CStdGLTexture(const CStdGLTexture &) = delete;
 	CStdGLTexture &operator=(const CStdGLTexture &) = delete;
@@ -175,6 +178,9 @@ public:
 
 public:
 	explicit operator bool() const { return texture; }
+
+private:
+	static void ThrowIfGLError();
 
 private:
 	std::array<std::int32_t, Dimensions> dimensions;

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -269,6 +269,7 @@ protected:
 	CStdGLTexture<GL_TEXTURE_1D, 1> GammaRedTexture;
 	CStdGLTexture<GL_TEXTURE_1D, 1> GammaGreenTexture;
 	CStdGLTexture<GL_TEXTURE_1D, 1> GammaBlueTexture;
+	bool gammaDisabled{false};
 
 public:
 	// General

--- a/src/StdGLCtx.cpp
+++ b/src/StdGLCtx.cpp
@@ -206,7 +206,7 @@ bool CStdGLCtx::PageFlip()
 	return true;
 }
 
-bool CStdGL::SaveDefaultGammaRamp(CStdWindow *pWindow)
+bool CStdGL::SaveDefaultGammaRampToMonitor(CStdWindow *pWindow)
 {
 	HDC hDC = GetDC(pWindow->GetRenderWindow());
 	if (hDC)
@@ -222,7 +222,7 @@ bool CStdGL::SaveDefaultGammaRamp(CStdWindow *pWindow)
 	return false;
 }
 
-bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool fForce)
+bool CStdGL::ApplyGammaRampToMonitor(CGammaControl &ramp, bool fForce)
 {
 	if (!MainCtx.hDC || (!Active && !fForce)) return false;
 	if (!SetDeviceGammaRamp(MainCtx.hDC, ramp.red))
@@ -373,7 +373,7 @@ bool CStdGLCtx::PageFlip()
 	return true;
 }
 
-bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool fForce)
+bool CStdGL::ApplyGammaRampToMonitor(CGammaControl &ramp, bool fForce)
 {
 	if (!DeviceReady() || (!Active && !fForce)) return false;
 	if (pApp->xf86vmode_major_version < 2) return false;
@@ -382,7 +382,7 @@ bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool fForce)
 		ramp.red, ramp.green, ramp.blue);
 }
 
-bool CStdGL::SaveDefaultGammaRamp(CStdWindow *pWindow)
+bool CStdGL::SaveDefaultGammaRampToMonitor(CStdWindow *pWindow)
 {
 	if (pApp->xf86vmode_major_version < 2) return false;
 	// Get the Display
@@ -531,13 +531,13 @@ bool CStdGLCtx::PageFlip()
 	return true;
 }
 
-bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool fForce)
+bool CStdGL::ApplyGammaRampToMonitor(CGammaControl &ramp, bool fForce)
 {
 	assert(ramp.size == 256);
 	return SDL_SetWindowGammaRamp(MainCtx.pWindow->sdlWindow, ramp.red, ramp.green, ramp.blue) == 0;
 }
 
-bool CStdGL::SaveDefaultGammaRamp(CStdWindow *pWindow)
+bool CStdGL::SaveDefaultGammaRampToMonitor(CStdWindow *pWindow)
 {
 	assert(DefRamp.size == 256);
 	return SDL_GetWindowGammaRamp(MainCtx.pWindow->sdlWindow, DefRamp.red, DefRamp.green, DefRamp.blue) == 0;


### PR DESCRIPTION
![unknown](https://user-images.githubusercontent.com/18363765/198839473-5aaa63de-78b5-48d5-9ae4-418900cef0af.png)

GLSL shaders now do the gamma calculation. For this purpose, the gamma ramp is directly copied into a 256x3 texture.
The old way of setting the system's gamma ramp directly is still used for the non-shader code path for older systems.

TODO:
- [x] 256x3 is a non power-of-two texture, which requires OpenGL 2.0 and won't be handled well by old GPUs. While those could just use the non-shader path, increasing the texture size to 256x4 at the expense of 256 bytes would solve that issue. 
- [x] Add error checking for texture creation - at the moment, the game will start with a black screen with no error logged even if it couldn't be created properly.
- [x] `DrawQuadDw` looks weird with certain gamma values, e.g. the example given in [the docs](https://crdocs.clonkspot.org/de/sdk/script/fn/SetGamma.html).
- [x] Implement `Graphics.DisableGamma` properly - the shader currently still samples the gamma texture even if gamma is disabled. `DisableGamma` should disable any gamma-related code entirely.