### PR TITLE
changed DrawMap() function to allow access to named objects of the MapCreator if kept

### DIFF
--- a/src/C4Landscape.cpp
+++ b/src/C4Landscape.cpp
@@ -2659,11 +2659,16 @@ bool C4Landscape::DrawMap(int32_t iX, int32_t iY, int32_t iWdt, int32_t iHgt, co
 	FakeLS.MapWdt.Set(iMapWdt, 0, iMapWdt, iMapWdt);
 	FakeLS.MapHgt.Set(iMapHgt, 0, iMapHgt, iMapHgt);
 	// create map creator
-	C4MapCreatorS2 MapCreator(&FakeLS, &Game.TextureMap, &Game.Material, Game.Parameters.StartupPlayerCount);
+	std::unique_ptr<C4MapCreatorS2> MapCreator;
+	// If KeepMapCreator=1 we copy the existing creator to gain access to the named overlays
+	if (!pMapCreator) 
+		MapCreator = std::make_unique<C4MapCreatorS2>(&FakeLS, &Game.TextureMap, &Game.Material, Game.Parameters.StartupPlayerCount);
+	else
+	    MapCreator = std::make_unique<C4MapCreatorS2>(*pMapCreator, &FakeLS);
 	// read file
-	MapCreator.ReadScript(szMapDef);
+	MapCreator->ReadScript(szMapDef);
 	// render map
-	CSurface8 *sfcMap = MapCreator.Render(nullptr);
+	CSurface8 *sfcMap = MapCreator->Render(nullptr);
 	if (!sfcMap) return false;
 	// map it to the landscape
 	bool fSuccess = MapToLandscape(sfcMap, 0, 0, iMapWdt, iMapHgt, iX, iY);

--- a/src/C4MapCreatorS2.cpp
+++ b/src/C4MapCreatorS2.cpp
@@ -141,8 +141,12 @@ C4MCNode::C4MCNode(C4MCNode *pOwner, C4MCNode &rTemplate, bool fClone)
 	// copy children from template
 	for (C4MCNode *pChild = rTemplate.Child0; pChild; pChild = pChild->Next)
 		pChild->clone(this);
-	// no name
-	*Name = 0;
+
+    // Preserve the name if pOwner is a MCN_Node, which is only the case if pOwner is a C4MapCreatorS2
+    if (pOwner && pOwner->Type() == MCN_Node)
+        SCopy(rTemplate.Name, Name, C4MaxName);
+    else 
+        *Name = 0;  // Default behavior: reset the name
 }
 
 C4MCNode::~C4MCNode()
@@ -686,6 +690,21 @@ C4MapCreatorS2::C4MapCreatorS2(C4SLandscape *pLandscape, C4TextureMap *pTexMap, 
 	// store members
 	Landscape = pLandscape; TexMap = pTexMap; MatMap = pMatMap;
 	PlayerCount = iPlayerCount;
+	// set engine field for default stuff
+	DefaultMap.MapCreator = this;
+	DefaultOverlay.MapCreator = this;
+	DefaultPoint.MapCreator = this;
+	// default to landscape settings
+	Default();
+}
+
+C4MapCreatorS2::C4MapCreatorS2(C4MapCreatorS2 &rTemplate, C4SLandscape *pLandscape) : C4MCNode(nullptr, rTemplate, true)
+{
+	// me r b creator
+	MapCreator = this;
+	// store members
+	Landscape = pLandscape; TexMap = rTemplate.TexMap; MatMap = rTemplate.MatMap;
+	PlayerCount = rTemplate.PlayerCount;
 	// set engine field for default stuff
 	DefaultMap.MapCreator = this;
 	DefaultOverlay.MapCreator = this;

--- a/src/C4MapCreatorS2.h
+++ b/src/C4MapCreatorS2.h
@@ -349,7 +349,9 @@ class C4MapCreatorS2 : public C4MCNode
 {
 public:
 	C4MapCreatorS2(C4SLandscape *pLandscape, C4TextureMap *pTexMap, C4MaterialMap *pMatMap, int iPlayerCount);
+	C4MapCreatorS2(C4MapCreatorS2 &rTemplate, C4SLandscape *pLandscape); // construct of template
 	~C4MapCreatorS2();
+
 
 	void Default(); // set default data
 	void Clear(); // clear any data


### PR DESCRIPTION
This implements DrawCreatorMap() function for LC. DrawCreatorMap uses the MapCreator used for the generation of the initial map from Landscape.txt to draw a map with named overlays the same way DrawMap() would. Like DrawDefMap it requires KeepMapCreator=1. The way it is implemented, it can also be used to append named overlays to the MapCreator.

DrawCreatorMap(0,0,LandscapeWidth(),LandscapeHeight(),"map newMap{Rock{y=0};Paper{y=33;};Scissors{y=67;};};")

Would draw a new map using overlays with the names "Rock", "Paper" and "Scissors" if they're defined in the Landscape.txt. Additonally the map "newMap" is appended to the MapCreator, so DrawDefMap(0,0,LandscapeWidth(),LandscapeHeight(),"newMap") is now possible even if newMap was not initially defined in the Landscape.txt

This implementation did not require changes to the C4MapCreatorS2.

Note: The C4MapCreatorS2::GetMap() function does always provide a drawable map if one is present in the MapCreator-Tree (i.e. is defined in Landscape.txt or appended to the MapCreator using DrawCreatorMap) thus calling DrawCreatorMap() will draw a map even if only a named overlay is defined. 