### PR TITLE
Fix dropping of items and digging after letting go from scale/hangle

### DIFF
--- a/src/C4Object.cpp
+++ b/src/C4Object.cpp
@@ -3543,9 +3543,13 @@ void C4Object::DirectCom(uint8_t byCom, int32_t iData) // By player ObjectCom
 void C4Object::AutoStopDirectCom(uint8_t byCom, int32_t iData) // By DirecCom
 {
 	C4Player *pPlayer = Game.Players.Get(Controller);
-	auto LetGoAndForgetCom = [&](int xdir) {
+	const auto LetGoAndForgetCom = [pPlayer, this](const int xdir)
+	{
 		// Suppress unwanted dropping of items or digging after releasing from scale/hangle
-		if (ObjectComLetGo(this, xdir)) pPlayer->LastCom = COM_None;
+		if (ObjectComLetGo(this, xdir))
+		{
+			pPlayer->LastCom = COM_None;
+		}
 	};
 	// Control by procedure
 	switch (GetProcedure())

--- a/src/C4Object.cpp
+++ b/src/C4Object.cpp
@@ -3543,6 +3543,10 @@ void C4Object::DirectCom(uint8_t byCom, int32_t iData) // By player ObjectCom
 void C4Object::AutoStopDirectCom(uint8_t byCom, int32_t iData) // By DirecCom
 {
 	C4Player *pPlayer = Game.Players.Get(Controller);
+	auto LetGoAndForgetCom = [&](int xdir) {
+		// Suppress unwanted dropping of items or digging after releasing from scale/hangle
+		if (ObjectComLetGo(this, xdir)) pPlayer->LastCom = COM_None;
+	};
 	// Control by procedure
 	switch (GetProcedure())
 	{
@@ -3589,14 +3593,14 @@ void C4Object::AutoStopDirectCom(uint8_t byCom, int32_t iData) // By DirecCom
 		switch (byCom)
 		{
 		case COM_Left:
-			if (Action.Dir == DIR_Right) ObjectComLetGo(this, -1);
+			if (Action.Dir == DIR_Right) LetGoAndForgetCom(-1);
 			else AutoStopUpdateComDir();
 			break;
 		case COM_Right:
-			if (Action.Dir == DIR_Left) ObjectComLetGo(this, +1);
+			if (Action.Dir == DIR_Left) LetGoAndForgetCom(+1);
 			else AutoStopUpdateComDir();
 			break;
-		case COM_Dig:    ObjectComLetGo(this, (Action.Dir == DIR_Left) ? +1 : -1);
+		case COM_Dig:    LetGoAndForgetCom(Action.Dir == DIR_Left ? +1 : -1); break;
 		case COM_Throw:  PlayerObjectCommand(Owner, C4CMD_Drop); break;
 		default: AutoStopUpdateComDir();
 		}
@@ -3605,8 +3609,8 @@ void C4Object::AutoStopDirectCom(uint8_t byCom, int32_t iData) // By DirecCom
 	case DFA_HANGLE:
 		switch (byCom)
 		{
-		case COM_Down:    ObjectComLetGo(this, 0); break;
-		case COM_Dig:     ObjectComLetGo(this, 0); break;
+		case COM_Down:    LetGoAndForgetCom(0); break;
+		case COM_Dig:     LetGoAndForgetCom(0); break;
 		case COM_Throw:   PlayerObjectCommand(Owner, C4CMD_Drop); break;
 		default: AutoStopUpdateComDir();
 		}


### PR DESCRIPTION
Fixes #119.

Dropping items when letting go from scaling was just the missing `break`.

The hangle case is a bit more complicated because the drop command is initiated by checking `LastComDownDouble`, which is set based on `LastCom`. So by clearing `LastCom` when letting go, the problem goes away. Dropping items after landing as before is still possible by pressing Down-Down-Throw again while in the air instead of just Down-Throw as before.

I'm not sure if the `if` in line 3548 is really necessary, because `ObjectComLetGo` can only return false for an object which can scale/hangle but has no "Jump" action, so it can not let go. At that point, we can as well leave `LastCom` alone, I guess, maybe the object wants to do something special with it...

Weapons were not tested, and I'm unsure if there are any weird interactions with scripts or other custom content.