### PR TITLE
Add C4DeletionTrackable for a common way to avoid use-after-free with non-owned pointers

### DIFF
--- a/cmake/filelists/Engine.txt
+++ b/cmake/filelists/Engine.txt
@@ -34,6 +34,7 @@ src/C4Def.h
 src/C4DefGraphics.cpp
 src/C4DefGraphics.h
 src/C4DelegatedIterable.h
+src/C4DeletionTrackable.h
 src/C4DevmodeDlg.cpp
 src/C4DevmodeDlg.h
 src/C4DownloadDlg.cpp

--- a/src/C4DeletionTrackable.h
+++ b/src/C4DeletionTrackable.h
@@ -1,0 +1,104 @@
+/*
+ * LegacyClonk
+ *
+ * Copyright (c) 2023, The LegacyClonk Team and contributors
+ *
+ * Distributed under the terms of the ISC license; see accompanying file
+ * "COPYING" for details.
+ *
+ * "Clonk" is a registered trademark of Matthes Bender, used with permission.
+ * See accompanying file "TRADEMARK" for details.
+ *
+ * To redistribute this file separately, substitute the full license texts
+ * for the above references.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <utility>
+
+class C4DeletionTrackable
+{
+	class Tracker
+	{
+	public:
+		constexpr Tracker(C4DeletionTrackable *tracked) noexcept : tracked{tracked}
+		{
+			assert(!tracked->tracker);
+			tracked->tracker = this;
+		}
+
+		Tracker(const Tracker &) = delete;
+
+		constexpr Tracker(Tracker &&other) noexcept : tracked{std::exchange(other.tracked, nullptr)}, isDeleted{other.isDeleted}
+		{
+			if (!tracked)
+			{
+				return;
+			}
+
+			assert(tracked->tracker == &other);
+			tracked->tracker = this;
+		}
+
+		Tracker &operator=(const Tracker &) = delete;
+
+		constexpr Tracker &operator=(Tracker &&other) noexcept
+		{
+			clear();
+			tracked = std::exchange(other.tracked, nullptr);
+			isDeleted = other.isDeleted;
+
+			if (tracked)
+			{
+				assert(tracked->tracker == &other);
+				tracked->tracker = this;
+			}
+
+			return *this;
+		}
+
+		constexpr ~Tracker() noexcept
+		{
+			clear();
+		}
+
+		constexpr bool IsDeleted() const noexcept
+		{
+			return isDeleted;
+		}
+
+	private:
+		constexpr void clear() noexcept
+		{
+			if (tracked && !isDeleted)
+			{
+				assert(tracked->tracker == this);
+				tracked->tracker = nullptr;
+			}
+		}
+
+		C4DeletionTrackable *tracked{nullptr};
+		bool isDeleted{false};
+
+		friend C4DeletionTrackable;
+	};
+
+public:
+	constexpr ~C4DeletionTrackable() noexcept
+	{
+		if (tracker)
+		{
+			tracker->isDeleted = true;
+		}
+	}
+
+	[[nodiscard]] constexpr Tracker TrackDeletion() noexcept
+	{
+		return {this};
+	}
+
+private:
+	Tracker *tracker{nullptr};
+};

--- a/src/C4Effects.h
+++ b/src/C4Effects.h
@@ -24,6 +24,7 @@
 
 #include "C4Aul.h"
 #include "C4Constants.h"
+#include "C4DeletionTrackable.h"
 #include "C4EnumeratedObjectPtr.h"
 #include "C4ValueList.h"
 
@@ -73,7 +74,7 @@ typedef unsigned long C4ID;
 #define C4Fx_FireMode_Last      3 // largest valid fire mode
 
 // generic object effect
-class C4Effect
+class C4Effect : private C4DeletionTrackable
 {
 public:
 	char Name[C4MaxDefString + 1]; // name of effect

--- a/src/C4ObjectMenu.cpp
+++ b/src/C4ObjectMenu.cpp
@@ -41,11 +41,6 @@ C4ObjectMenu::~C4ObjectMenu()
 	{
 		*ClearObjectPtr = nullptr;
 	}
-
-	if (IsDeleted)
-	{
-		*IsDeleted = true;
-	}
 }
 
 void C4ObjectMenu::Default()
@@ -516,8 +511,7 @@ bool C4ObjectMenu::MenuCommand(const char *szCommand, bool fIsCloseCommand)
 	{
 		ClearObjectPtr = &l_Object;
 	}
-	bool isDeleted{false};
-	IsDeleted = &isDeleted;
+	const auto deletionTracker = TrackDeletion();
 
 	switch (eCallbackType)
 	{
@@ -538,10 +532,9 @@ bool C4ObjectMenu::MenuCommand(const char *szCommand, bool fIsCloseCommand)
 
 	if ((!l_Permanent || fIsCloseCommand) && l_Object) l_Object->AutoContextMenu(l_LastSelection);
 
-	if (!isDeleted)
+	if (!deletionTracker.IsDeleted())
 	{
 		ClearObjectPtr = nullptr;
-		IsDeleted = nullptr;
 	}
 
 	return true;

--- a/src/C4ObjectMenu.h
+++ b/src/C4ObjectMenu.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "C4DeletionTrackable.h"
 #include "C4Menu.h"
 
 enum
@@ -44,7 +45,7 @@ enum
 	C4MN_Contents = 18
 };
 
-class C4ObjectMenu : public C4Menu
+class C4ObjectMenu : public C4Menu, private C4DeletionTrackable
 {
 public:
 	C4ObjectMenu();
@@ -63,7 +64,6 @@ protected:
 	CallbackType eCallbackType;
 	bool UserMenu; // set for script created menus; user menus do CloseQuery and MenuSelection callbacks
 	bool CloseQuerying; // recursion check for close query callback
-	bool *IsDeleted{nullptr};
 
 	void LocalInit(C4Object *pObject, bool fUserMenu);
 


### PR DESCRIPTION
This seems to have been forgotten, but seems useful to have.
It also fixes a C4Effect-Kill bug which still seems unaddressed on master.