### PR TITLE
C4Update: Add AllowMissingTarget option to AutoUpdate.txt

### DIFF
--- a/src/C4Update.cpp
+++ b/src/C4Update.cpp
@@ -811,7 +811,7 @@ bool C4UpdatePackage::MkUp(C4Group *pGrp1, C4Group *pGrp2, C4GroupEx *pUpGrp, bo
 			extern const char **C4Group_SortList;
 			UpdGroup.SortByList(C4Group_SortList, ChildGrp2.GetName());
 			UpdGroup.Close(false);
-			// always add the entire group if mising targets are allowed
+			// always add the entire group if missing targets are allowed
 			// otherwise check entry times
 			if (AllowMissingTarget || !pGrp1 || (pGrp1->EntryTime(strItemName) != pGrp2->EntryTime(strItemName)))
 				childIncludeInUpdate = true;

--- a/src/C4Update.h
+++ b/src/C4Update.h
@@ -34,6 +34,7 @@ public:
 	char DestPath[_MAX_PATH + 1];
 	int32_t GrpUpdate;
 	int32_t UpGrpCnt; // number of file versions that can be updated by this package
+	bool AllowMissingTarget; // if true, missing target files are not considered an error
 	uint32_t GrpChks1[C4UP_MaxUpGrpCnt], GrpChks2;
 	uint32_t GrpContentsCRC1[C4UP_MaxUpGrpCnt], GrpContentsCRC2;
 
@@ -59,7 +60,7 @@ public:
 	bool Execute(C4Group *pGroup);
 	static bool Optimize(C4Group *pGrpFrom, const char *strTarget);
 	CheckResult Check(C4Group *pGroup);
-	bool MakeUpdate(const char *strFile1, const char *strFile2, const char *strUpdateFile, const char *strName = nullptr);
+	bool MakeUpdate(const char *strFile1, const char *strFile2, const char *strUpdateFile, const char *strName, bool allowMissingTarget);
 
 protected:
 	bool DoUpdate(C4Group *pGrpFrom, class C4GroupEx *pGrpTo, const char *strFileName);

--- a/src/C4Update.h
+++ b/src/C4Update.h
@@ -67,7 +67,7 @@ protected:
 	bool DoGrpUpdate(C4Group *pUpdateData, class C4GroupEx *pGrpTo);
 	static bool Optimize(C4Group *pGrpFrom, class C4GroupEx *pGrpTo, const char *strFileName);
 
-	bool MkUp(C4Group *pGrp1, C4Group *pGrp2, C4GroupEx *pUpGr, bool *fModified);
+	bool MkUp(C4Group *pGrp1, C4Group *pGrp2, C4GroupEx *pUpGr, bool &includeInUpdate);
 
 	CStdFile Log;
 

--- a/src/c4group_ng.cpp
+++ b/src/c4group_ng.cpp
@@ -363,7 +363,7 @@ bool ProcessGroup(const char *FilenamePar)
 								std::println(stderr, "Closing failed: {}", hGroup.GetError());
 							}
 							// generate
-							else if (!Upd.MakeUpdate(argv[iArg + 1], argv[iArg + 2], szFilename, argv[iArg + 3]))
+							else if (!Upd.MakeUpdate(argv[iArg + 1], argv[iArg + 2], szFilename, argv[iArg + 3], argv[iArg][2] == 'a'))
 							{
 								std::println(stderr, "Update generation failed.");
 							}
@@ -645,7 +645,7 @@ int main(int argc, char *argv[])
 		std::println("          -v View  -l List  -d Delete  -r Rename  -s Sort");
 		std::println("          -p Pack  -u Unpack  -x Explode");
 		std::println("          -k Print maker");
-		std::println("          -g [source] [target] [title] Make update");
+		std::println("          -g[a] [source] [target] [title] Make update [allow missing target]");
 		std::println("          -y[d] Apply update [and delete group file]");
 		std::println("");
 		std::println("Options:  -v Verbose -r Recursive -p Prompt at end");

--- a/src/c4group_ng.cpp
+++ b/src/c4group_ng.cpp
@@ -645,7 +645,7 @@ int main(int argc, char *argv[])
 		std::println("          -v View  -l List  -d Delete  -r Rename  -s Sort");
 		std::println("          -p Pack  -u Unpack  -x Explode");
 		std::println("          -k Print maker");
-		std::println("          -g[a] [source] [target] [title] Make update [allow missing target]");
+		std::println("          -g[a] [source] [target] [title] Make update [and allow missing target group when applying update]");
 		std::println("          -y[d] Apply update [and delete group file]");
 		std::println("");
 		std::println("Options:  -v Verbose -r Recursive -p Prompt at end");


### PR DESCRIPTION
This allows an updated group to be created if no previous version exists.
Also expose it as c4group flag 'a' in '-g[a]'.