### PR TITLE
Add nix build definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ CMAKE_DEPENDENT_OPTION(USE_LIBNOTIFY "Use libnotify for desktop notifications" O
 option(USE_MINIUPNPC "Use miniupnpc for UPnP support" ON)
 # USE_WINDOWS_RUNTIME
 CMAKE_DEPENDENT_OPTION(USE_WINDOWS_RUNTIME "Use Windows Runtime features" ON "WIN32" OFF)
+# USE_SYSTEM_SPDLOG
+option(USE_SYSTEM_SPDLOG "Use system spdlog instead of local checkout" OFF)
 
 if (USE_LTO)
 	include(CheckIPOSupported)
@@ -416,20 +418,25 @@ if (USE_SDL_MIXER)
 endif ()
 
 # Link spdlog
-FetchContent_Declare(
-	spdlog
-	GIT_REPOSITORY https://github.com/gabime/spdlog.git
-	GIT_TAG v1.14.1
-)
+if (USE_SYSTEM_SPDLOG)
+	find_package(spdlog REQUIRED)
+else ()
+	FetchContent_Declare(
+		spdlog
+		GIT_REPOSITORY https://github.com/gabime/spdlog.git
+		GIT_TAG v1.14.1
+	)
 
-set(SPDLOG_BUILD_EXAMPLE OFF)
-set(SPDLOG_DISABLE_DEFAULT_LOGGER ON)
-set(SPDLOG_ENABLE_PCH ${USE_PCH})
-set(SPDLOG_USE_STD_FORMAT ON)
+	set(SPDLOG_BUILD_EXAMPLE OFF)
+	set(SPDLOG_DISABLE_DEFAULT_LOGGER ON)
+	set(SPDLOG_ENABLE_PCH ${USE_PCH})
+	set(SPDLOG_USE_STD_FORMAT ON)
 
-FetchContent_MakeAvailable(spdlog)
+	FetchContent_MakeAvailable(spdlog)
 
-target_compile_definitions(spdlog PUBLIC SPDLOG_EOL=\"\\x0A\")
+	target_compile_definitions(spdlog PUBLIC SPDLOG_EOL=\"\\x0A\")
+endif ()
+
 target_link_libraries(standard spdlog::spdlog)
 
 # Link Windows Imaging Component

--- a/tools/default.nix
+++ b/tools/default.nix
@@ -1,0 +1,78 @@
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+
+  content ? null, # path to content repository
+  useSDLMainloop ? false,
+  withDeveloperMode ? true,
+}:
+
+assert useSDLMainloop -> !withDeveloperMode;
+
+pkgs.stdenv.mkDerivation {
+  name = "legacyclonk";
+
+  src = builtins.filterSource (path: type: ! builtins.elem (baseNameOf path) [
+    ".git" # leave out .git as it changes often in ways that do not affect the build
+    "default.nix" # default.nix might change, but the only thing that matters is what it evaluates to, and nix takes care of that
+    "result" # build result is irrelevant
+    "build"
+  ]) ./..;
+
+  enableParallelInstalling = false;
+
+  nativeBuildInputs = with pkgs; [ cmake pkg-config ];
+
+  dontStrip = true;
+
+  buildInputs = with pkgs; [
+    openssl
+    curl
+    fmt
+    freetype
+    iconv
+    libjpeg
+    glew
+    libpng
+    SDL2
+    SDL2_mixer
+    libnotify
+    miniupnpc
+    zlib
+    (spdlog.overrideAttrs (final: prev: {
+      cmakeFlags = prev.cmakeFlags ++ [
+        (lib.cmakeBool "SPDLOG_FMT_EXTERNAL" false)
+        (lib.cmakeBool "SPDLOG_USE_STD_FORMAT" true)
+      ];
+    }))
+  ] ++ lib.optional withDeveloperMode gtk3
+    ++ lib.optionals (!useSDLMainloop) [ xorg.libXpm xorg.libXxf86vm ];
+
+  cmakeBuildType = "RelWithDebInfo";
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_SPDLOG" true)
+    (lib.cmakeBool "USE_SDL_MAINLOOP" useSDLMainloop)
+    (lib.cmakeBool "WITH_DEVELOPER_MODE" withDeveloperMode)
+  ];
+
+  postBuild = ''
+    for path in ../planet/*.c4g ${lib.optionalString (content != null) "${content}/*.c4?"}
+    do
+      group=$(basename "$path")
+      echo "$group"
+      cp -rt . "$path"
+      chmod -R +w "$group"
+      ./c4group "$group" -p
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -t "$out" clonk c4group *.c4?
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
On a system with nix installed, LegacyClonk can be built with

    nix-build tools/default.nix

Unfortunately, it's not possible to run the result directly since LegacyClonk requires a writeable game directory.