### PR TITLE
Update deprecated ubuntu GA runner

### DIFF
--- a/autobuild/ci.toml
+++ b/autobuild/ci.toml
@@ -74,7 +74,7 @@ platform-suffix = 'win32'
 debugrec = true
 
 [matrix.linux]
-runner = 'ubuntu-20.04'
+runner = 'ubuntu-24.04'
 
 [[matrix.linux.config]]
 arch = 'x64'


### PR DESCRIPTION
Ubuntu 20.04 is no longer available in GAs, builds will fail. Read https://github.com/actions/runner-images/issues/11101