### PR TITLE
SDL3 + SDL Mixer 3 Migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,13 +436,13 @@ if (NOT USE_WIC)
 	target_link_libraries(clonk PNG::PNG)
 endif ()
 
-# Link SDL2
+# Link SDL3
 if (USE_SDL_MAINLOOP OR USE_SDL_MIXER)
-	find_package(SDL2 REQUIRED)
-	if (SDL2_FOUND AND USE_SDL_MAINLOOP)
+	find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3)
+	if (SDL3_FOUND AND USE_SDL_MAINLOOP)
 		set(USE_SDL_FOR_GAMEPAD ON)
 	endif ()
-	target_link_libraries(clonk SDL2::SDL2)
+	target_link_libraries(clonk SDL3::SDL3)
 endif ()
 
 # Link SDL2_mixer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,7 @@ option(USE_TESTS "Enable testing" OFF)
 CMAKE_DEPENDENT_OPTION(ENABLE_SOUND "Compile with sound support" ON
 	"NOT USE_CONSOLE" OFF)
 # USE_SDL_MIXER
-CMAKE_DEPENDENT_OPTION(USE_SDL_MIXER "Whether SDL2_mixer shall be used for sound" ON
-	"ENABLE_SOUND" OFF)
+CMAKE_DEPENDENT_OPTION(USE_SDL_MIXER "Whether SDL3_mixer shall be used for sound" ON "ENABLE_SOUND" OFF)
 # USE_SDL_MAINLOOP
 if (APPLE)
 	set(USE_SDL_MAINLOOP_DEFAULT ON)
@@ -445,10 +444,10 @@ if (USE_SDL_MAINLOOP OR USE_SDL_MIXER)
 	target_link_libraries(clonk SDL3::SDL3)
 endif ()
 
-# Link SDL2_mixer
+# Link SDL3_mixer
 if (USE_SDL_MIXER)
-	find_package(SDL2_mixer REQUIRED)
-	target_link_libraries(clonk SDL2_mixer::SDL2_mixer)
+	find_package(SDL3_mixer REQUIRED)
+	target_link_libraries(clonk SDL3_mixer::SDL3_mixer)
 endif ()
 
 # Link spdlog

--- a/src/C4Application.cpp
+++ b/src/C4Application.cpp
@@ -175,12 +175,12 @@ void C4Application::DoInit()
 	// Init carrier window
 	if (isFullScreen)
 	{
-		if (!FullScreen.Init(this))
+		const C4Rect bounds{0, 0, static_cast<int32_t>(Config.Graphics.ResX * GetScale()), static_cast<int32_t>(Config.Graphics.ResY * GetScale())};
+		if (!FullScreen.Init(this, bounds))
 		{
 			Clear(); return;
 		}
 		pWindow = &FullScreen;
-		pWindow->SetSize(static_cast<int32_t>(Config.Graphics.ResX * GetScale()), static_cast<int32_t>(Config.Graphics.ResY * GetScale()));
 		SetDisplayMode(Config.Graphics.UseDisplayMode);
 
 #ifdef _WIN32
@@ -193,7 +193,8 @@ void C4Application::DoInit()
 	}
 	else
 	{
-		if (!Console.Init(this))
+		const C4Rect bounds{25, 200, 450, 450};
+		if (!Console.Init(this, bounds))
 		{
 			Clear(); return;
 		}

--- a/src/C4AudioSystemSdl.cpp
+++ b/src/C4AudioSystemSdl.cpp
@@ -29,12 +29,12 @@
 #include <optional>
 #include <span>
 
-#include <SDL_mixer.h>
+#include <SDL3_mixer/SDL_mixer.h>
 
 class C4AudioSystemSdl : public C4AudioSystem
 {
 public:
-	C4AudioSystemSdl(int maxChannels, bool preferLinearResampling);
+	C4AudioSystemSdl(int maxTracks, bool preferLinearResampling);
 	~C4AudioSystemSdl() noexcept override;
 
 	void FadeOutMusic(std::int32_t ms) override;
@@ -43,28 +43,28 @@ public:
 	void SetMusicVolume(float volume) override;
 	void StopMusic() override;
 	void UnpauseMusic() override;
+	MIX_Track *GetFreeAudioTrack();
+	void ReturnAudioTrack(MIX_Track *track);
+	SDL_PropertiesID loopProperty;
+	SDL_PropertiesID noLoopProperty;
+	std::shared_ptr<spdlog::logger> logger;
 
 private:
-	static constexpr int Frequency = 44100;
-	static constexpr Uint16 Format = AUDIO_S16SYS;
-	static constexpr int NumChannels = 2;
-	static constexpr int BytesPerSecond =
-	Frequency * (SDL_AUDIO_BITSIZE(Format) / 8) * NumChannels;
-	static constexpr int InvalidChannel{-1};
+	static constexpr int frequency = 44100;
+	static constexpr SDL_AudioFormat format = SDL_AUDIO_S16;
+	static constexpr int numChannels = 2;
+	static constexpr int bytesPerSecond =
+	frequency * (SDL_AUDIO_BITSIZE(format) / 8) * numChannels;
 
-	// Smart pointers for SDL_mixer objects
-	using SDLMixChunkUniquePtr = C4DeleterFunctionUniquePtr<Mix_FreeChunk>;
-	using SDLMixMusicUniquePtr = C4DeleterFunctionUniquePtr<Mix_FreeMusic>;
-
-	std::optional<StdSdlSubSystem> system;
+	std::optional<StdSdlSubSystem> sdlSubsystem;
 
 	static void ThrowIfFailed(const char *funcName, bool failed, std::string_view errorMessage = {});
 
-	template <typename T>
-	using SampleLoadFunc = T *(*)(SDL_RWops *, int);
+	static MIX_Audio *LoadSampleCheckMpegLayer3Header(const void *buf, const std::size_t size);
 
-	template <typename T>
-	static T *LoadSampleCheckMpegLayer3Header(SampleLoadFunc<T> loadFunc, const char *funcName, const void *buf, const std::size_t size);
+	MIX_Mixer *mixer;
+	MIX_Track *musicTrack;
+	std::vector<MIX_Track*> audioTracks;
 
 public:
 
@@ -74,12 +74,15 @@ public:
 		MusicFileSdl(const void *buf, std::size_t size);
 
 	private:
-		SDLMixMusicUniquePtr sample;
+		MIX_Audio *sample;
 
 		friend class C4AudioSystemSdl;
 	};
 
-	MusicFile *CreateMusicFile(const void *buf, std::size_t size) override { return new MusicFileSdl{buf, size}; }
+	MusicFile *CreateMusicFile(const void *buf, std::size_t size) override
+	{
+		return new MusicFileSdl{buf, size};
+	}
 
 	class SoundFileSdl;
 
@@ -95,17 +98,20 @@ public:
 		void SetPosition(std::uint32_t ms) override;
 		void SetVolumeAndPan(float volume, float pan) override;
 		void Unpause() override;
-		int GetChannelId() const { return channel.load(std::memory_order_acquire); }
-		void ClearChannelId() { channel.store(InvalidChannel, std::memory_order_release); }
+		MIX_Track *GetAssignedTrack()
+		{
+			return assignedTrack;
+		};
 
 	private:
-		std::atomic_int channel;
+		MIX_Track *assignedTrack;
+		MIX_StereoGains stereoGains;
 	};
 
 	SoundChannel *CreateSoundChannel(const SoundFile *const sound, bool loop) override
 	{
+		// Caller manages lifetime.
 		const auto channel = new SoundChannelSdl{static_cast<const SoundFileSdl *>(sound), loop};
-		playingChannels[channel->GetChannelId()] = channel;
 		return channel;
 	}
 
@@ -118,7 +124,7 @@ public:
 		std::uint32_t GetDuration() const override;
 
 	private:
-		const SDLMixChunkUniquePtr sample;
+		MIX_Audio *sample;
 
 		friend class C4AudioSystemSdl;
 	};
@@ -126,64 +132,100 @@ public:
 	virtual SoundFile *CreateSoundFile(const void *buf, std::size_t size) override { return new SoundFileSdl{buf, size}; }
 
 private:
-	std::vector<SoundChannelSdl *> playingChannels;
-
 	static inline C4AudioSystemSdl *instance{nullptr};
-	static void ChannelFinished(int channel);
+	static void TrackFinished(void *userdata, MIX_Track *track);
 };
 
 // this is used instead of MIX_MAX_VOLUME, because MIX_MAX_VOLUME is very loud and easily leads to clipping
 // the lower volume gives more headroom until clipping occurs
 // the selected volume is chosen to be similar to FMod's original volume
-static constexpr auto MaximumMusicVolume = 80;
+static constexpr auto maximumMusicVolume = 80;
 
 // higher than MaximumMusicVolume to compensate for lower maximum panning volume
-static constexpr auto MaximumSoundVolume = 100;
+static constexpr auto maximumSoundVolume = 100;
 
-C4AudioSystemSdl::C4AudioSystemSdl(const int maxChannels, const bool preferLinearResampling)
+const char* GetAudioFormatString(const SDL_AudioFormat& audioFormat)
+{
+	switch (audioFormat)
+	{
+	case SDL_AUDIO_UNKNOWN:
+		return "SDL_AUDIO_UNKNOWN";
+	case SDL_AUDIO_U8:
+		return "SDL_AUDIO_U8";
+	case SDL_AUDIO_S8:
+		return "SDL_AUDIO_S8";
+	case SDL_AUDIO_S16LE:
+		return "SDL_AUDIO_S16LE";
+	case SDL_AUDIO_S16BE:
+		return "SDL_AUDIO_S16BE";
+	case SDL_AUDIO_S32LE:
+		return "SDL_AUDIO_S32LE";
+	case SDL_AUDIO_S32BE:
+		return "SDL_AUDIO_S32BE";
+	case SDL_AUDIO_F32LE:
+		return "SDL_AUDIO_F32LE";
+	case SDL_AUDIO_F32BE:
+		return "SDL_AUDIO_F32BE";
+	}
+	return "None";
+}
+
+C4AudioSystemSdl::C4AudioSystemSdl(const int maxTracks, const bool preferLinearResampling)
 {
 	assert(!instance);
 	instance = this;
 
-	auto logger = Application.LogSystem.CreateLoggerWithDifferentName(Config.Logging.AudioSystem, "C4AudioSystem");
+	logger = Application.LogSystem.CreateLoggerWithDifferentName(Config.Logging.AudioSystem, "C4AudioSystem");
 
 	// Check SDL_mixer version
-	SDL_version compile_version;
-	MIX_VERSION(&compile_version);
-	const auto link_version = Mix_Linked_Version();
-	logger->info("SDL_mixer runtime version is {}.{}.{} (compiled with {}.{}.{})",
-		link_version->major, link_version->minor, link_version->patch,
-		compile_version.major, compile_version.minor, compile_version.patch);
+	std::int32_t compile_version{MIX_Version()};
+	logger->info("SDL_mixer runtime version is {}.{}.{} (compiled with {})",
+		SDL_MIXER_MAJOR_VERSION, SDL_MIXER_MINOR_VERSION, SDL_MIXER_MICRO_VERSION,
+		compile_version);
 
+
+	// TODO: This hint doesn't exist anymore in SDL3. Also linear seems to never have been a valid option.
+	/*
 	// Try to enable linear resampling if requested
 	if (preferLinearResampling)
 	{
 		if (!SDL_SetHint(SDL_HINT_AUDIO_RESAMPLING_MODE, "linear"))
+		{
 			logger->error("SDL_SetHint(SDL_HINT_AUDIO_RESAMPLING_MODE, \"linear\") failed");
+		}
 	}
+	*/
 
 	// Initialize SDL_mixer
 	StdSdlSubSystem system{SDL_INIT_AUDIO};
-	ThrowIfFailed("Mix_OpenAudioDevice",
-		Mix_OpenAudioDevice(Frequency, Format, NumChannels, 1024, nullptr, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE) != 0);
+	ThrowIfFailed("MIX_Init", !MIX_Init());
+	const SDL_AudioSpec audioSpec{format, numChannels, frequency};
+	mixer = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &audioSpec);
+	ThrowIfFailed("MIX_CreateMixerDevice", mixer == nullptr);
 
-	int frequency;
-	Uint16 format;
-	int channels;
-	Mix_QuerySpec(&frequency, &format, &channels);
+	SDL_AudioSpec spec;
+	MIX_GetMixerFormat(mixer, &spec);
+	logger->debug("SDL_mixer device spec: frequency = {} Hz, format = {}, channels = {}", spec.freq, GetAudioFormatString(spec.format), spec.channels);
 
-	logger->debug("SDL_mixer device spec: frequency = {} Hz, format = {}, channels = {}", frequency, format, channels);
+	this->sdlSubsystem.emplace(std::move(system));
+	audioTracks.reserve(maxTracks);
+	for (std::int32_t trackIndex{0}; trackIndex < maxTracks; ++trackIndex)
+	{
+		audioTracks.emplace_back(MIX_CreateTrack(mixer));
+		MIX_SetTrackStoppedCallback(audioTracks.back(), TrackFinished, nullptr);
+	}
+	musicTrack = MIX_CreateTrack(mixer);
 
-	Mix_AllocateChannels(maxChannels);
-	Mix_ChannelFinished(ChannelFinished);
-	this->system.emplace(std::move(system));
-	playingChannels.resize(maxChannels);
+	loopProperty = SDL_CreateProperties();
+	SDL_SetNumberProperty(loopProperty, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
+	noLoopProperty = SDL_CreateProperties();
+	SDL_SetNumberProperty(noLoopProperty, MIX_PROP_PLAY_LOOPS_NUMBER, 0);
 }
 
 C4AudioSystemSdl::~C4AudioSystemSdl() noexcept
 {
-	Mix_CloseAudio();
-	Mix_Quit();
+	MIX_DestroyMixer(mixer); // Will also destroy audio tracks.
+	MIX_Quit();
 }
 
 void C4AudioSystemSdl::ThrowIfFailed(const char *const funcName, const bool failed, std::string_view errorMessage)
@@ -192,7 +234,7 @@ void C4AudioSystemSdl::ThrowIfFailed(const char *const funcName, const bool fail
 	{
 		if (errorMessage.empty())
 		{
-			errorMessage = Mix_GetError();
+			errorMessage = SDL_GetError();
 		}
 
 		throw std::runtime_error{std::format("SDL_mixer: {} failed: {}", funcName, errorMessage)};
@@ -201,48 +243,73 @@ void C4AudioSystemSdl::ThrowIfFailed(const char *const funcName, const bool fail
 
 void C4AudioSystemSdl::FadeOutMusic(const std::int32_t ms)
 {
-	ThrowIfFailed("Mix_FadeOutMusic", Mix_FadeOutMusic(ms) != 1);
+	ThrowIfFailed("MIX_StopTrack", MIX_StopTrack(musicTrack, MIX_TrackMSToFrames(musicTrack, ms)) != 1);
 }
 
 bool C4AudioSystemSdl::IsMusicPlaying() const
 {
-	return Mix_PlayingMusic() == 1;
+	return MIX_TrackPlaying(musicTrack);
 }
 
 void C4AudioSystemSdl::PlayMusic(const C4AudioSystem::MusicFile *const music, const bool loop)
 {
-	ThrowIfFailed("Mix_PlayMusic", Mix_PlayMusic(static_cast<const MusicFileSdl *>(music)->sample.get(), (loop ? -1 : 1)) == -1);
+	MIX_SetTrackAudio(musicTrack, static_cast<const MusicFileSdl *>(music)->sample);
+	ThrowIfFailed("MIX_PlayTrack", !MIX_PlayTrack(musicTrack, loop ? loopProperty : noLoopProperty));
 }
 
 void C4AudioSystemSdl::SetMusicVolume(const float volume)
 {
-	Mix_VolumeMusic(std::lrint(volume * MaximumMusicVolume));
+	MIX_SetTrackGain(musicTrack, volume * (maximumMusicVolume / 100.0f));
 }
 
 void C4AudioSystemSdl::StopMusic()
 {
-	Mix_HaltMusic();
+	MIX_StopTrack(musicTrack, MIX_TrackMSToFrames(musicTrack, 100));
 }
 
-void C4AudioSystemSdl::UnpauseMusic() { /* Not supported */ }
-
-template <typename T>
-T *C4AudioSystemSdl::LoadSampleCheckMpegLayer3Header(const SampleLoadFunc<T> loadFunc, const char *const funcName, const void *const buf, const std::size_t size)
+void C4AudioSystemSdl::UnpauseMusic()
 {
-	const auto direct = loadFunc(SDL_RWFromConstMem(buf, size), SDL_TRUE);
+	MIX_ResumeTrack(musicTrack);
+}
+
+MIX_Track* C4AudioSystemSdl::GetFreeAudioTrack()
+{
+	if (audioTracks.size())
+	{
+		MIX_Track *freeTrack{audioTracks.back()};
+		audioTracks.pop_back();
+		return freeTrack;
+	}
+	return nullptr;
+}
+
+void C4AudioSystemSdl::ReturnAudioTrack(MIX_Track *track)
+{
+	audioTracks.push_back(track);
+}
+
+MIX_Audio *C4AudioSystemSdl::LoadSampleCheckMpegLayer3Header(const void *const buf, const std::size_t size)
+{
+	if(!C4AudioSystemSdl::instance)
+	{
+		ThrowIfFailed("LoadSampleCheckMpegLayer3Header", true, "C4AudioSystemSdl Instance invalid.");
+		return nullptr;
+	}
+
+	MIX_Audio *const direct{MIX_LoadAudio_IO(C4AudioSystemSdl::instance->mixer, SDL_IOFromConstMem(buf, size), true, true)};
 	if (direct)
 	{
 		return direct;
 	}
-	const std::string error{Mix_GetError()};
+	const std::string error{SDL_GetError()};
 
 	// According to http://www.idea2ic.com/File_Formats/MPEG%20Audio%20Frame%20Header.pdf
 	// Maximum possible frame size = 144 * max bit rate / min sample rate + padding
 	// chosen values are limited to layer 3
-	static constexpr std::size_t MaxFrameSize{144 * 320'000 / 8'000 + 1};
+	static constexpr std::size_t maxFrameSize{144 * 320'000 / 8'000 + 1};
 
 	const std::span data{reinterpret_cast<const std::byte *>(buf), size};
-	const std::size_t limit{std::min(data.size(), MaxFrameSize)};
+	const std::size_t limit{std::min(data.size(), maxFrameSize)};
 
 	for (std::size_t i{0}; i < limit - 4; ++i)
 	{
@@ -266,74 +333,99 @@ T *C4AudioSystemSdl::LoadSampleCheckMpegLayer3Header(const SampleLoadFunc<T> loa
 		if ((byte4 & std::byte{0x03}) == std::byte{0x02}) continue;
 
 		// at this point there seems to be a valid MPEG frame header
-		const auto sample = loadFunc(SDL_RWFromConstMem(data.data() + i, size - i), SDL_TRUE);
+		MIX_Audio *const sample{MIX_LoadAudio_IO(C4AudioSystemSdl::instance->mixer, SDL_IOFromConstMem(data.data() + i, size - i), true, true)};
 		if (sample)
 		{
 			return sample;
 		}
 	}
 
-	ThrowIfFailed(funcName, true, error);
+	ThrowIfFailed("MIX_LoadAudio", true, error);
 	return nullptr;
 }
 
 C4AudioSystemSdl::MusicFileSdl::MusicFileSdl(const void *const buf, const std::size_t size)
-	: sample{LoadSampleCheckMpegLayer3Header(Mix_LoadMUS_RW, "Mix_LoadMUS_RW", buf, size)}
+	: sample{LoadSampleCheckMpegLayer3Header(buf, size)}
 {}
 
 C4AudioSystemSdl::SoundFileSdl::SoundFileSdl(const void *const buf, const std::size_t size)
-	: sample{LoadSampleCheckMpegLayer3Header(Mix_LoadWAV_RW, "Mix_LoadWAV_RW", buf, size)}
+	: sample{LoadSampleCheckMpegLayer3Header(buf, size)}
 {}
 
 std::uint32_t C4AudioSystemSdl::SoundFileSdl::GetDuration() const
 {
-	return 1000 * sample->alen / BytesPerSecond;
+	return MIX_AudioFramesToMS(sample, MIX_GetAudioDuration(sample));
 }
 
 C4AudioSystemSdl::SoundChannelSdl::SoundChannelSdl(const SoundFileSdl *const sound, const bool loop)
-	: channel{Mix_PlayChannel(-1, sound->sample.get(), (loop ? -1 : 0))}
 {
-	ThrowIfFailed("Mix_PlayChannel", GetChannelId() == InvalidChannel);
+	if(!C4AudioSystemSdl::instance)
+	{
+		ThrowIfFailed("SoundChannelSdl", true, "C4AudioSystemSdl Instance invalid.");
+		return;
+	}
+
+	stereoGains.left = 0.0f;
+	stereoGains.right = 0.0f;
+
+	MIX_Track *track{C4AudioSystemSdl::instance->GetFreeAudioTrack()};
+	if(track)
+	{
+		this->assignedTrack = track;
+		ThrowIfFailed("MIX_SetTrackAudio", !MIX_SetTrackAudio(track, sound->sample));
+		ThrowIfFailed("MIX_PlayTrack", !MIX_PlayTrack(track, loop ? C4AudioSystemSdl::instance->loopProperty : C4AudioSystemSdl::instance->noLoopProperty));
+		MIX_PauseTrack(track); // Unpaused in outer AudioSystem
+	}
 }
 
 C4AudioSystemSdl::SoundChannelSdl::~SoundChannelSdl()
 {
-	if (const auto ch = channel.load(std::memory_order::acquire); ch != InvalidChannel)
+	if(C4AudioSystemSdl::instance && assignedTrack)
 	{
-		Mix_HaltChannel(ch);
+		MIX_StopTrack(assignedTrack, 0);
+		C4AudioSystemSdl::instance->ReturnAudioTrack(assignedTrack);
 	}
 }
 
 bool C4AudioSystemSdl::SoundChannelSdl::IsPlaying() const
 {
-	const auto ch = channel.load(std::memory_order::acquire);
-	return ch != InvalidChannel && Mix_Playing(ch) == 1;
+	if(assignedTrack)
+	{
+		return MIX_TrackPlaying(assignedTrack);
+	}
+	return false;
 }
 
 void C4AudioSystemSdl::SoundChannelSdl::SetPosition(const std::uint32_t ms)
 {
-	// Not supported
+	if(assignedTrack)
+	{
+		MIX_SetTrackPlaybackPosition(assignedTrack, MIX_TrackMSToFrames(assignedTrack, ms));
+	}
 }
 
 void C4AudioSystemSdl::SoundChannelSdl::SetVolumeAndPan(const float volume, const float pan)
 {
-	const auto ch = channel.load(std::memory_order::acquire);
-	if (ch == InvalidChannel) return;
-
-	Mix_Volume(ch, std::lrint(volume * MaximumSoundVolume));
-	const Uint8
-		left  = static_cast<Uint8>(std::clamp(std::lrint((1.0f - pan) * 192.0f), 0L, 192L)),
-		right = static_cast<Uint8>(std::clamp(std::lrint((1.0f + pan) * 192.0f), 0L, 192L));
-	ThrowIfFailed("Mix_SetPanning", Mix_SetPanning(ch, left, right) == 0);
+	if(!assignedTrack)
+	{
+		return;
+	}
+	ThrowIfFailed("MIX_SetTrackGain", !MIX_SetTrackGain(assignedTrack, volume * (maximumSoundVolume / 100.0f)));
+	stereoGains.left = 1.0f - pan;
+	stereoGains.right = 1.0f + pan;
+	ThrowIfFailed("MIX_SetTrackStereo", !MIX_SetTrackStereo(assignedTrack, &stereoGains));
 }
 
-void C4AudioSystemSdl::SoundChannelSdl::Unpause() { /* Not supported */ }
-
-void C4AudioSystemSdl::ChannelFinished(int channel)
+void C4AudioSystemSdl::SoundChannelSdl::Unpause()
 {
-	auto &soundInstance = instance->playingChannels[channel];
-	soundInstance->ClearChannelId();
-	soundInstance = nullptr;
+	if(assignedTrack)
+	{
+		MIX_ResumeTrack(assignedTrack);
+	}
+}
+
+void C4AudioSystemSdl::TrackFinished(void *userdata, MIX_Track *track)
+{
 }
 
 C4AudioSystem *CreateC4AudioSystemSdl(int maxChannels, const bool preferLinearResampling)

--- a/src/C4Console.cpp
+++ b/src/C4Console.cpp
@@ -274,9 +274,9 @@ void C4Console::HandleMessage(XEvent &e)
 
 #endif // _WIN32/USE_X11
 
-bool C4Console::Init(CStdApp *const app)
+bool C4Console::Init(CStdApp *const app, const C4Rect &bounds)
 {
-	return Init(app, LoadResStr(C4ResStrTableKey::IDS_CNS_CONSOLE));
+	return Init(app, LoadResStr(C4ResStrTableKey::IDS_CNS_CONSOLE), bounds);
 }
 
 bool C4Console::Init(CStdApp *const app, const char *const title, const C4Rect &bounds, CStdWindow *const parent)

--- a/src/C4Console.h
+++ b/src/C4Console.h
@@ -71,7 +71,7 @@ public:
 	void Default();
 	virtual void Clear() override;
 	virtual void Close() override;
-	bool Init(CStdApp *app);
+	bool Init(CStdApp *app, const C4Rect &bounds);
 	bool Init(CStdApp *app, const char *title, const class C4Rect &bounds = CStdWindow::DefaultBounds, CStdWindow *parent = nullptr) override;
 	void Execute();
 	void ClearPointers(C4Object *pObj);

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -465,12 +465,12 @@ C4FullScreen::~C4FullScreen()
 	delete pMenu;
 }
 
-bool C4FullScreen::Init(CStdApp *const app)
+bool C4FullScreen::Init(CStdApp *const app, const C4Rect &bounds)
 {
 #ifdef _WIN32
 	return Init(app, STD_PRODUCT);
 #else
-	return CStdWindow::Init(app, STD_PRODUCT);
+	return CStdWindow::Init(app, STD_PRODUCT, bounds);
 #endif
 }
 

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -429,18 +429,40 @@ void C4FullScreen::HandleMessage(SDL_Event &e)
 		break;
 
 	case SDL_EVENT_WINDOW_RESIZED :
+	{
+
 		int width, height;
 		SDL_GetWindowSizeInPixels(sdlWindow, &width, &height);
-		Application.SetResolution(width, height);
+		if (width != 0 && height != 0)
+		{
+			Application.SetResolution(width, height);
+		}
 		break;
+	}
 	case SDL_EVENT_WINDOW_MINIMIZED :
 	case SDL_EVENT_WINDOW_HIDDEN :
+	{
+		const auto oldActive = Application.Active;
 		Application.Active = false;
+
+		if (Application.DDraw && oldActive)
+		{
+			Application.DDraw->InvalidateDeviceObjects();
+		}
 		break;
+	}
 	case SDL_EVENT_WINDOW_SHOWN :
 	case SDL_EVENT_WINDOW_EXPOSED :
+	{
+		const auto oldActive = Application.Active;
 		Application.Active = true;
+
+		if (Application.DDraw && !oldActive)
+		{
+			Application.DDraw->RestoreDeviceObjects();
+		}
 		break;
+	}
 
 	}
 }

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -327,47 +327,39 @@ namespace
 	void sdlToC4MCBtn(const SDL_MouseButtonEvent &e,
 		int32_t &button)
 	{
-		static int lastLeftClick = 0, lastRightClick = 0;
-
 		button = C4MC_Button_None;
 
 		switch (e.button)
 		{
 		case SDL_BUTTON_LEFT:
-			if (e.state == SDL_PRESSED)
-				if (timeGetTime() - lastLeftClick < 400)
-				{
-					lastLeftClick = 0;
-					button = C4MC_Button_LeftDouble;
-				}
-				else
-				{
-					lastLeftClick = timeGetTime();
-					button = C4MC_Button_LeftDown;
-				}
+			if (e.state == SDL_EVENT_MOUSE_BUTTON_DOWN)
+			{
+				button = e.clicks % 2 == 0 ? C4MC_Button_LeftDouble : C4MC_Button_LeftDown;
+			}
 			else
+			{
 				button = C4MC_Button_LeftUp;
+			}
 			break;
 		case SDL_BUTTON_RIGHT:
-			if (e.state == SDL_PRESSED)
-				if (timeGetTime() - lastRightClick < 400)
-				{
-					lastRightClick = 0;
-					button = C4MC_Button_RightDouble;
-				}
-				else
-				{
-					lastRightClick = timeGetTime();
-					button = C4MC_Button_RightDown;
-				}
+			if (e.state == SDL_EVENT_MOUSE_BUTTON_DOWN)
+			{
+				button = e.clicks % 2 == 0 ? C4MC_Button_RightDouble : C4MC_Button_RightDown;
+			}
 			else
+			{
 				button = C4MC_Button_RightUp;
+			}
 			break;
 		case SDL_BUTTON_MIDDLE:
 			if (e.state == SDL_PRESSED)
+			{
 				button = C4MC_Button_MiddleDown;
+			}
 			else
+			{
 				button = C4MC_Button_MiddleUp;
+			}
 			break;
 		}
 	}
@@ -379,42 +371,42 @@ void C4FullScreen::HandleMessage(SDL_Event &e)
 {
 	switch (e.type)
 	{
-	case SDL_TEXTINPUT:
+	case SDL_EVENT_TEXT_INPUT :
 	{
 		CharIn(e.text.text);
 		break;
 	}
-	case SDL_KEYDOWN:
+	case SDL_EVENT_KEY_DOWN :
 	{
-		Game.DoKeyboardInput(e.key.keysym.scancode, KEYEV_Down,
+		Game.DoKeyboardInput(e.key.scancode, KEYEV_Down,
 			Application.IsAltDown(),
 			Application.IsControlDown(),
 			Application.IsShiftDown(),
 			false, nullptr);
 		break;
 	}
-	case SDL_KEYUP:
-		Game.DoKeyboardInput(e.key.keysym.scancode, KEYEV_Up,
+	case SDL_EVENT_KEY_UP :
+		Game.DoKeyboardInput(e.key.scancode, KEYEV_Up,
 			Application.IsAltDown(),
 			Application.IsControlDown(),
 			Application.IsShiftDown(), false, nullptr);
 		break;
-	case SDL_MOUSEMOTION:
+	case SDL_EVENT_MOUSE_MOTION :
 	{
 		const auto scale = GetInputScale();
 		Game.GraphicsSystem.MouseMove(C4MC_Button_None, e.motion.x * scale, e.motion.y * scale, Application.GetModifiers(), nullptr);
 		break;
 	}
-	case SDL_MOUSEWHEEL:
+	case SDL_EVENT_MOUSE_WHEEL :
 	{
 		const auto scale = GetInputScale();
-		int x, y;
+		float x, y;
 		SDL_GetMouseState(&x, &y);
-		Game.GraphicsSystem.MouseMove(C4MC_Button_Wheel, x * scale, y * scale, (e.wheel.y * 60) << 16, nullptr);
+		Game.GraphicsSystem.MouseMove(C4MC_Button_Wheel, x * scale, y * scale, static_cast<std::int32_t>(e.wheel.y * 60) << 16, nullptr);
 		break;
 	}
-	case SDL_MOUSEBUTTONUP:
-	case SDL_MOUSEBUTTONDOWN:
+	case SDL_EVENT_MOUSE_BUTTON_UP :
+	case SDL_EVENT_MOUSE_BUTTON_DOWN :
 	{
 		const auto scale = GetInputScale();
 		int32_t button;
@@ -422,30 +414,28 @@ void C4FullScreen::HandleMessage(SDL_Event &e)
 		Game.GraphicsSystem.MouseMove(button, e.button.x * scale, e.button.y * scale, Application.GetModifiers(), nullptr);
 		break;
 	}
-	case SDL_JOYAXISMOTION:
-	case SDL_JOYHATMOTION:
-	case SDL_JOYBALLMOTION:
-	case SDL_JOYBUTTONDOWN:
-	case SDL_JOYBUTTONUP:
+	case SDL_EVENT_JOYSTICK_AXIS_MOTION :
+	case SDL_EVENT_JOYSTICK_HAT_MOTION :
+	case SDL_EVENT_JOYSTICK_BALL_MOTION :
+	case SDL_EVENT_JOYSTICK_BUTTON_DOWN :
+	case SDL_EVENT_JOYSTICK_BUTTON_UP :
 		Application.pGamePadControl->FeedEvent(e);
 		break;
-	case SDL_WINDOWEVENT:
-		switch (e.window.event)
-		{
-		case SDL_WINDOWEVENT_RESIZED:
-			int width, height;
-			SDL_GL_GetDrawableSize(sdlWindow, &width, &height);
-			Application.SetResolution(width, height);
-			break;
-		case SDL_WINDOWEVENT_MINIMIZED:
-		case SDL_WINDOWEVENT_HIDDEN:
-			Application.Active = false;
-			break;
-		case SDL_WINDOWEVENT_SHOWN:
-		case SDL_WINDOWEVENT_EXPOSED:
-			Application.Active = true;
-		}
+
+	case SDL_EVENT_WINDOW_RESIZED :
+		int width, height;
+		SDL_GetWindowSizeInPixels(sdlWindow, &width, &height);
+		Application.SetResolution(width, height);
 		break;
+	case SDL_EVENT_WINDOW_MINIMIZED :
+	case SDL_EVENT_WINDOW_HIDDEN :
+		Application.Active = false;
+		break;
+	case SDL_EVENT_WINDOW_SHOWN :
+	case SDL_EVENT_WINDOW_EXPOSED :
+		Application.Active = true;
+		break;
+
 	}
 }
 

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -446,7 +446,11 @@ void C4FullScreen::CharIn(const char *c)
 {
 	if (Game.pGUI)
 	{
+#ifdef USE_SDL_MAINLOOP
+		Game.pGUI->CharIn(TextEncodingConverter.Utf8ToClonk(c).c_str());
+#else
 		Game.pGUI->CharIn(TextEncodingConverter.SystemToClonk(c).c_str());
+#endif
 	}
 }
 #endif

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -474,7 +474,7 @@ C4FullScreen::~C4FullScreen()
 bool C4FullScreen::Init(CStdApp *const app, const C4Rect &bounds)
 {
 #ifdef _WIN32
-	return Init(app, STD_PRODUCT);
+	return Init(app, STD_PRODUCT, bounds);
 #else
 	return CStdWindow::Init(app, STD_PRODUCT, bounds);
 #endif

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -371,6 +371,12 @@ void C4FullScreen::HandleMessage(SDL_Event &e)
 {
 	switch (e.type)
 	{
+	case SDL_EVENT_WINDOW_MOUSE_ENTER:
+		SDL_HideCursor();
+		break;
+	case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+		SDL_ShowCursor();
+		break;
 	case SDL_EVENT_TEXT_INPUT :
 	{
 		CharIn(e.text.text);

--- a/src/C4FullScreen.cpp
+++ b/src/C4FullScreen.cpp
@@ -332,7 +332,7 @@ namespace
 		switch (e.button)
 		{
 		case SDL_BUTTON_LEFT:
-			if (e.state == SDL_EVENT_MOUSE_BUTTON_DOWN)
+			if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
 			{
 				button = e.clicks % 2 == 0 ? C4MC_Button_LeftDouble : C4MC_Button_LeftDown;
 			}
@@ -342,7 +342,7 @@ namespace
 			}
 			break;
 		case SDL_BUTTON_RIGHT:
-			if (e.state == SDL_EVENT_MOUSE_BUTTON_DOWN)
+			if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
 			{
 				button = e.clicks % 2 == 0 ? C4MC_Button_RightDouble : C4MC_Button_RightDown;
 			}
@@ -352,7 +352,7 @@ namespace
 			}
 			break;
 		case SDL_BUTTON_MIDDLE:
-			if (e.state == SDL_PRESSED)
+			if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
 			{
 				button = C4MC_Button_MiddleDown;
 			}

--- a/src/C4FullScreen.h
+++ b/src/C4FullScreen.h
@@ -41,7 +41,7 @@ public:
 	// User requests close
 	virtual void Close() override;
 	virtual void CharIn(const char *c) override;
-	bool Init(CStdApp *app);
+	bool Init(CStdApp *app, const C4Rect &bounds);
 #ifdef USE_X11
 	bool HideCursor() const override { return true; }
 	virtual void HandleMessage(XEvent &e) override;

--- a/src/C4GamePadCon.cpp
+++ b/src/C4GamePadCon.cpp
@@ -293,7 +293,10 @@ C4GamePadControl::C4GamePadControl()
 		throw;
 	}
 	SDL_JoystickEventsEnabled();
-	if (!SDL_HasJoystick()) LogNTr("No Gamepad found");
+	if (!SDL_HasJoystick())
+	{
+		LogNTr("No Gamepad found");
+	}
 }
 
 C4GamePadControl::~C4GamePadControl() {}
@@ -436,9 +439,9 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 
 int C4GamePadControl::GetGamePadCount()
 {
-	std::int32_t JoystickNum = 0;
-	SDL_GetJoysticks(&JoystickNum);
-	return JoystickNum;
+	std::int32_t joystickNum{0};
+	SDL_GetJoysticks(&joystickNum);
+	return joystickNum;
 }
 
 C4GamePadOpener::C4GamePadOpener(int iGamepad)

--- a/src/C4GamePadCon.cpp
+++ b/src/C4GamePadCon.cpp
@@ -276,7 +276,7 @@ void C4GamePadOpener::SetGamePad(int iNewGamePad)
 
 #elif defined(USE_SDL_FOR_GAMEPAD)
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <stdexcept>
 
 C4GamePadControl::C4GamePadControl()
@@ -292,8 +292,8 @@ C4GamePadControl::C4GamePadControl()
 		// TODO: Handle
 		throw;
 	}
-	SDL_JoystickEventState(SDL_ENABLE);
-	if (!SDL_NumJoysticks()) LogNTr("No Gamepad found");
+	SDL_JoystickEventsEnabled();
+	if (!SDL_HasJoystick()) LogNTr("No Gamepad found");
 }
 
 C4GamePadControl::~C4GamePadControl() {}
@@ -306,11 +306,11 @@ void C4GamePadControl::Execute()
 	{
 		switch (event.type)
 		{
-		case SDL_JOYAXISMOTION:
-		case SDL_JOYBALLMOTION:
-		case SDL_JOYHATMOTION:
-		case SDL_JOYBUTTONDOWN:
-		case SDL_JOYBUTTONUP:
+		case SDL_EVENT_JOYSTICK_AXIS_MOTION :
+		case SDL_EVENT_JOYSTICK_BALL_MOTION :
+		case SDL_EVENT_JOYSTICK_HAT_MOTION :
+		case SDL_EVENT_JOYSTICK_BUTTON_DOWN :
+		case SDL_EVENT_JOYSTICK_BUTTON_UP :
 			FeedEvent(event);
 			break;
 		}
@@ -336,10 +336,10 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 {
 	switch (event.type)
 	{
-	case SDL_JOYHATMOTION:
+	case SDL_EVENT_JOYSTICK_HAT_MOTION :
 	{
 		SDL_Event fakeX;
-		fakeX.jaxis.type = SDL_JOYAXISMOTION;
+		fakeX.jaxis.type = SDL_EVENT_JOYSTICK_AXIS_MOTION;
 		fakeX.jaxis.which = event.jhat.which;
 		fakeX.jaxis.axis = event.jhat.hat * 2 + 6; /* *magic*number* */
 		fakeX.jaxis.value = 0;
@@ -360,10 +360,10 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 		FeedEvent(fakeY);
 		return;
 	}
-	case SDL_JOYBALLMOTION:
+	case SDL_EVENT_JOYSTICK_BALL_MOTION :
 	{
 		SDL_Event fake;
-		fake.jaxis.type = SDL_JOYAXISMOTION;
+		fake.jaxis.type = SDL_EVENT_JOYSTICK_AXIS_MOTION;
 		fake.jaxis.which = event.jball.which;
 		fake.jaxis.axis = event.jball.ball * 2 + 12; /* *magic*number* */
 		fake.jaxis.value = amplify(event.jball.xrel);
@@ -373,7 +373,7 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 		FeedEvent(event);
 		return;
 	}
-	case SDL_JOYAXISMOTION:
+	case SDL_EVENT_JOYSTICK_AXIS_MOTION :
 	{
 		C4KeyCode minCode = KEY_Gamepad(event.jaxis.which, KEY_JOY_Axis(event.jaxis.axis, false));
 		C4KeyCode maxCode = KEY_Gamepad(event.jaxis.which, KEY_JOY_Axis(event.jaxis.axis, true));
@@ -421,12 +421,12 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 		}
 		break;
 	}
-	case SDL_JOYBUTTONDOWN:
+	case SDL_EVENT_JOYSTICK_BUTTON_DOWN :
 		Game.DoKeyboardInput(
 			KEY_Gamepad(event.jbutton.which, KEY_JOY_Button(event.jbutton.button)),
 			KEYEV_Down, false, false, false, false);
 		break;
-	case SDL_JOYBUTTONUP:
+	case SDL_EVENT_JOYSTICK_BUTTON_UP :
 		Game.DoKeyboardInput(
 			KEY_Gamepad(event.jbutton.which, KEY_JOY_Button(event.jbutton.button)),
 			KEYEV_Up, false, false, false, false);
@@ -436,25 +436,27 @@ void C4GamePadControl::FeedEvent(SDL_Event &event)
 
 int C4GamePadControl::GetGamePadCount()
 {
-	return (SDL_NumJoysticks());
+	std::int32_t JoystickNum = 0;
+	SDL_GetJoysticks(&JoystickNum);
+	return JoystickNum;
 }
 
 C4GamePadOpener::C4GamePadOpener(int iGamepad)
 {
-	Joy = SDL_JoystickOpen(iGamepad);
+	Joy = SDL_OpenJoystick(iGamepad);
 	if (!Joy) LogNTr(spdlog::level::err, "SDL: {}", SDL_GetError());
 }
 
 C4GamePadOpener::~C4GamePadOpener()
 {
-	if (Joy) SDL_JoystickClose(Joy);
+	if (Joy) SDL_CloseJoystick(Joy);
 }
 
 void C4GamePadOpener::SetGamePad(int iGamepad)
 {
 	if (Joy)
-		SDL_JoystickClose(Joy);
-	Joy = SDL_JoystickOpen(iGamepad);
+		SDL_CloseJoystick(Joy);
+	Joy = SDL_OpenJoystick(iGamepad);
 	if (!Joy)
 		LogNTr(spdlog::level::err, "SDL: {}", SDL_GetError());
 }

--- a/src/C4GamePadCon.h
+++ b/src/C4GamePadCon.h
@@ -33,8 +33,6 @@
 #include <set>
 #endif
 
-struct _SDL_Joystick;
-typedef struct _SDL_Joystick SDL_Joystick;
 
 union SDL_Event;
 typedef union SDL_Event SDL_Event;
@@ -125,6 +123,6 @@ public:
 	~C4GamePadOpener();
 	void SetGamePad(int iNewGamePad);
 #ifdef USE_SDL_FOR_GAMEPAD
-	SDL_Joystick *Joy;
+	struct SDL_Joystick *Joy;
 #endif
 };

--- a/src/C4KeyboardInput.cpp
+++ b/src/C4KeyboardInput.cpp
@@ -29,7 +29,7 @@
 #endif
 
 #ifdef USE_SDL_MAINLOOP
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #endif
 
 // Key maps
@@ -378,7 +378,7 @@ std::string C4KeyCodeEx::KeyCode2String(C4KeyCode wCode, bool fHumanReadable, bo
 	std::string name;
 	if (fHumanReadable)
 	{
-		const auto key = SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(wCode));
+		const auto key = SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(wCode), SDL_KMOD_NONE, true);
 		name = TextEncodingConverter.Utf8ToClonk(SDL_GetKeyName(key));
 	}
 	else
@@ -456,7 +456,7 @@ void C4KeyCodeEx::CompileFunc(StdCompiler *pComp)
 bool C4KeyCodeEx::IsStandardAlphaNumeric() const noexcept
 {
 #ifdef USE_SDL_MAINLOOP
-	const int key{SDL_GetKeyName(SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(Key)))[0]};
+	const int key{SDL_GetKeyName(SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(Key), SDL_KMOD_NONE, true))[0]};
 #else
 	const auto key = Key;
 #endif

--- a/src/StdApp.h
+++ b/src/StdApp.h
@@ -136,7 +136,7 @@ struct _GIOChannel;
 #define MK_SHIFT (1 << 0)
 #elif defined(USE_SDL_MAINLOOP)
 #include <StdSdlSubSystem.h>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <optional>
 #define K_F1 SDL_SCANCODE_F1
 #define K_F2 SDL_SCANCODE_F2
@@ -180,9 +180,9 @@ struct _GIOChannel;
 #define KEY_X SDL_SCANCODE_X
 #define KEY_A SDL_SCANCODE_A
 #define KEY_F SDL_SCANCODE_F
-#define MK_ALT KMOD_ALT
-#define MK_CONTROL KMOD_CTRL
-#define MK_SHIFT KMOD_SHIFT
+#define MK_ALT SDL_KMOD_ALT
+#define MK_CONTROL SDL_KMOD_CTRL
+#define MK_SHIFT SDL_KMOD_SHIFT
 #elif defined(USE_CONSOLE)
 #define K_F1 0
 #define K_F2 0

--- a/src/StdAppUnix.cpp
+++ b/src/StdAppUnix.cpp
@@ -565,7 +565,7 @@ bool CStdApp::IsClipboardFull(const bool clipboard)
 #ifdef USE_X11
 	return XGetSelectionOwner(dpy, clipboard ? ClipboardAtoms[0] : XA_PRIMARY) != None;
 #elif defined(USE_SDL_MAINLOOP)
-	return SDL_HasClipboardText() == SDL_TRUE;
+	return SDL_HasClipboardText() == true;
 #elif defined(USE_CONSOLE)
 	return false;
 #endif
@@ -810,14 +810,14 @@ void CStdApp::HandleSDLEvent(SDL_Event &event)
 {
 	switch (event.type)
 	{
-	case SDL_QUIT:
+	case SDL_EVENT_QUIT :
 		Quit();
 		return;
 
-	case SDL_KEYDOWN:
-	case SDL_KEYUP:
+	case SDL_EVENT_KEY_DOWN :
+	case SDL_EVENT_KEY_UP :
 	{
-		KeyMask = event.key.keysym.mod;
+		KeyMask = event.key.mod;
 		break;
 	}
 	}

--- a/src/StdGL.cpp
+++ b/src/StdGL.cpp
@@ -793,7 +793,7 @@ CStdGLCtx *CStdGL::CreateContext(CStdWindow *const pWindow, CStdApp *const pApp)
 	if (!pWindow) return nullptr;
 
 #ifdef USE_SDL_MAINLOOP
-	if (SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1) != 0)
+	if (!SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1))
 	{
 		logger->error("SDL: Enabling context sharing failed: {}", SDL_GetError());
 	}
@@ -996,7 +996,8 @@ bool CStdGL::ApplyGammaRamp(CGammaControl &ramp, bool force)
 		return true;
 	}
 
-	return ApplyGammaRampToMonitor(ramp, force);
+	// TODO: Remove
+	//return ApplyGammaRampToMonitor(ramp, force);
 }
 
 bool CStdGL::SaveDefaultGammaRamp(CStdWindow *window)

--- a/src/StdGL.h
+++ b/src/StdGL.h
@@ -242,7 +242,7 @@ protected:
 	typedef struct __GLXcontextRec *GLXContext;
 	GLXContext ctx;
 #elif defined(USE_SDL_MAINLOOP)
-	/*SDL_GLContext*/ void *ctx;
+	SDL_GLContext ctx;
 #endif
 	int cx, cy; // context window size
 

--- a/src/StdGLCtx.cpp
+++ b/src/StdGLCtx.cpp
@@ -532,22 +532,14 @@ bool CStdGLCtx::PageFlip()
 	return true;
 }
 
-// TODO: Remove
 bool CStdGL::ApplyGammaRampToMonitor(CGammaControl &ramp, bool fForce)
 {
 	return false;
-	//assert(ramp.size == 256);
-	// Removed from SDL3 due to poor support in operating systems.
-	//return SDL_SetWindowGammaRamp(MainCtx.pWindow->sdlWindow, ramp.red, ramp.green, ramp.blue) == 0;
 }
 
-// TODO: Remove
 bool CStdGL::SaveDefaultGammaRampToMonitor(CStdWindow *pWindow)
 {
 	return false;
-	//assert(DefRamp.size == 256);
-	// Removed from SDL3 due to poor support in operating systems.
-	//return SDL_GetWindowGammaRamp(MainCtx.pWindow->sdlWindow, DefRamp.red, DefRamp.green, DefRamp.blue) == 0;
 }
 
 #endif // USE_X11/USE_SDL_MAINLOOP

--- a/src/StdGLCtx.cpp
+++ b/src/StdGLCtx.cpp
@@ -424,7 +424,7 @@ void CStdGLCtx::Clear()
 	Deselect();
 	if (ctx)
 	{
-		SDL_GL_DeleteContext(ctx);
+		SDL_GL_DestroyContext(ctx);
 		ctx = nullptr;
 	}
 	pWindow = nullptr;
@@ -435,6 +435,7 @@ bool CStdGLCtx::Init(CStdWindow *pWindow, CStdApp *)
 {
 	// safety
 	if (!pGL) return false;
+
 	ctx = SDL_GL_CreateContext(pWindow->sdlWindow);
 	if (!ctx)
 	{
@@ -466,7 +467,10 @@ bool CStdGLCtx::Init(CStdWindow *pWindow, CStdApp *)
 
 bool CStdGLCtx::Select(bool verbose, bool selectOnly)
 {
-	SDL_GL_MakeCurrent(this->pWindow->sdlWindow, ctx);
+	if (!SDL_GL_MakeCurrent(this->pWindow->sdlWindow, ctx))
+	{
+		throw std::runtime_error{std::string{"SDL_GL_MakeCurrent failed: "} + SDL_GetError()};
+	}
 	if (!selectOnly)
 	{
 		pGL->pCurrCtx = this;
@@ -494,7 +498,7 @@ bool CStdGLCtx::Select(bool verbose, bool selectOnly)
 
 void CStdGLCtx::DoDeselect()
 {
-	if (SDL_GL_MakeCurrent(this->pWindow->sdlWindow, nullptr) != 0)
+	if (!SDL_GL_MakeCurrent(this->pWindow->sdlWindow, nullptr))
 	{
 		throw std::runtime_error{std::string{"SDL_GL_MakeCurrent failed: "} + SDL_GetError()};
 	}
@@ -528,16 +532,22 @@ bool CStdGLCtx::PageFlip()
 	return true;
 }
 
+// TODO: Remove
 bool CStdGL::ApplyGammaRampToMonitor(CGammaControl &ramp, bool fForce)
 {
-	assert(ramp.size == 256);
-	return SDL_SetWindowGammaRamp(MainCtx.pWindow->sdlWindow, ramp.red, ramp.green, ramp.blue) == 0;
+	return false;
+	//assert(ramp.size == 256);
+	// Removed from SDL3 due to poor support in operating systems.
+	//return SDL_SetWindowGammaRamp(MainCtx.pWindow->sdlWindow, ramp.red, ramp.green, ramp.blue) == 0;
 }
 
+// TODO: Remove
 bool CStdGL::SaveDefaultGammaRampToMonitor(CStdWindow *pWindow)
 {
-	assert(DefRamp.size == 256);
-	return SDL_GetWindowGammaRamp(MainCtx.pWindow->sdlWindow, DefRamp.red, DefRamp.green, DefRamp.blue) == 0;
+	return false;
+	//assert(DefRamp.size == 256);
+	// Removed from SDL3 due to poor support in operating systems.
+	//return SDL_GetWindowGammaRamp(MainCtx.pWindow->sdlWindow, DefRamp.red, DefRamp.green, DefRamp.blue) == 0;
 }
 
 #endif // USE_X11/USE_SDL_MAINLOOP

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -59,14 +59,14 @@ bool CStdWindow::Init(CStdApp *const app, const char *const title, const C4Rect 
 	displayMode = DisplayMode::Window;
 	this->app = app;
 
-	sdlWindow = SDL_CreateWindow(title, bounds.x, bounds.y, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+	sdlWindow = SDL_CreateWindow(title, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
 	ThrowIfFailed("SDL_CreateWindow", !sdlWindow);
+	SDL_SetWindowPosition(sdlWindow, bounds.x, bounds.y);
 	SDL_StartTextInput(sdlWindow);
 
 	return true;
 }
 
-void CStdWindow::Clear() {}
 void CStdWindow::Clear()
 {
 	if (sdlWindow)

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -72,7 +72,7 @@ void CStdWindow::Clear() {}
 
 bool CStdWindow::GetSize(C4Rect &rect)
 {
-	SDL_GL_GetDrawableSize(sdlWindow, &width, &height);
+	SDL_GetWindowSizeInPixels(sdlWindow, &width, &height);
 	rect = {0, 0, width, height};
 	return true;
 }
@@ -91,37 +91,39 @@ void CStdWindow::SetTitle(const char *const Title)
 
 void CStdWindow::FlashWindow()
 {
-#ifdef __APPLE__
-	void requestUserAttention();
-	requestUserAttention();
-#endif
+	if (sdlWindow)
+	{
+		SDL_FlashWindow(sdlWindow, SDL_FLASH_BRIEFLY);
+	}
 }
 
 void CStdWindow::SetDisplayMode(const DisplayMode mode)
 {
 	if (mode == DisplayMode::Fullscreen)
 	{
-		ThrowIfFailed("SDL_SetWindowFullscreen", SDL_SetWindowFullscreen(sdlWindow, SDL_WINDOW_FULLSCREEN_DESKTOP) != 0);
+		ThrowIfFailed("SDL_SetWindowFullscreen", !SDL_SetWindowFullscreen(sdlWindow, true));
 	}
 	else
 	{
 		if (displayMode == DisplayMode::Fullscreen)
 		{
-			const auto currentDisplay = SDL_GetWindowDisplayIndex(sdlWindow);
-			ThrowIfFailed("SDL_GetWindowDisplayIndex", currentDisplay < 0);
-			SDL_DisplayMode mode;
-			ThrowIfFailed("SDL_GetCurrentDisplayMode", SDL_GetCurrentDisplayMode(currentDisplay, &mode) != 0);
-
-			width = mode.w - 100;
-			height = mode.h - 100;
+			const auto currentDisplay = SDL_GetDisplayForWindow(sdlWindow);
+			ThrowIfFailed("SDL_GetWindowDisplayIndex", currentDisplay <= 0);
+			const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(currentDisplay);
+			ThrowIfFailed("SDL_GetCurrentDisplayMode", mode == nullptr);
+			if(mode)
+			{
+				width = mode->w - 100;
+				height = mode->h - 100;
+			}
 		}
 
-		ThrowIfFailed("SDL_SetWindowFullscreen", SDL_SetWindowFullscreen(sdlWindow, 0) != 0);
+		ThrowIfFailed("SDL_SetWindowFullscreen", !SDL_SetWindowFullscreen(sdlWindow, false));
 		SDL_SetWindowSize(sdlWindow, width, height);
 	}
 
 	displayMode = mode;
-	ThrowIfFailed("SDL_ShowCursor", SDL_ShowCursor(SDL_DISABLE) < 0);
+	ThrowIfFailed("SDL_ShowCursor", !SDL_ShowCursor());
 }
 
 void CStdWindow::SetProgress(uint32_t) {} // stub
@@ -132,7 +134,7 @@ float CStdWindow::GetInputScale()
 	SDL_GetWindowSize(sdlWindow, &width, &height);
 
 	int drawableWidth, drawableHeight;
-	SDL_GL_GetDrawableSize(sdlWindow, &drawableWidth, &drawableHeight);
+	SDL_GetWindowSizeInPixels(sdlWindow, &drawableWidth, &drawableHeight);
 
 	return static_cast<float>(drawableWidth) / static_cast<float>(width);
 }

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -61,11 +61,19 @@ bool CStdWindow::Init(CStdApp *const app, const char *const title, const C4Rect 
 
 	sdlWindow = SDL_CreateWindow(title, bounds.x, bounds.y, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 	ThrowIfFailed("SDL_CreateWindow", !sdlWindow);
+	SDL_StartTextInput(sdlWindow);
 
 	return true;
 }
 
 void CStdWindow::Clear() {}
+void CStdWindow::Clear()
+{
+	if (sdlWindow)
+	{
+		SDL_StopTextInput(sdlWindow);
+	}
+}
 
 // Window size is automatically managed by CStdApp's display mode management.
 // Just remember the size for others to query.

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -62,6 +62,7 @@ bool CStdWindow::Init(CStdApp *const app, const char *const title, const C4Rect 
 	sdlWindow = SDL_CreateWindow(title, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
 	ThrowIfFailed("SDL_CreateWindow", !sdlWindow);
 	SDL_SetWindowPosition(sdlWindow, bounds.x, bounds.y);
+	SDL_SyncWindow(sdlWindow);
 	SDL_StartTextInput(sdlWindow);
 
 	return true;
@@ -110,7 +111,7 @@ void CStdWindow::SetDisplayMode(const DisplayMode mode)
 	if (mode == DisplayMode::Fullscreen)
 	{
 		ThrowIfFailed("SDL_SetWindowFullscreen", !SDL_SetWindowFullscreen(sdlWindow, true));
-		SDL_SetWindowPosition(sdlWindow, 0, 0);
+		SDL_SyncWindow(sdlWindow);
 	}
 	else
 	{
@@ -129,6 +130,7 @@ void CStdWindow::SetDisplayMode(const DisplayMode mode)
 
 		ThrowIfFailed("SDL_SetWindowFullscreen", !SDL_SetWindowFullscreen(sdlWindow, false));
 		SDL_SetWindowSize(sdlWindow, width, height);
+		SDL_SyncWindow(sdlWindow);
 	}
 
 	displayMode = mode;

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -110,6 +110,7 @@ void CStdWindow::SetDisplayMode(const DisplayMode mode)
 	if (mode == DisplayMode::Fullscreen)
 	{
 		ThrowIfFailed("SDL_SetWindowFullscreen", !SDL_SetWindowFullscreen(sdlWindow, true));
+		SDL_SetWindowPosition(sdlWindow, 0, 0);
 	}
 	else
 	{

--- a/src/StdSDLWindow.cpp
+++ b/src/StdSDLWindow.cpp
@@ -132,7 +132,6 @@ void CStdWindow::SetDisplayMode(const DisplayMode mode)
 	}
 
 	displayMode = mode;
-	ThrowIfFailed("SDL_ShowCursor", !SDL_ShowCursor());
 }
 
 void CStdWindow::SetProgress(uint32_t) {} // stub

--- a/src/StdSdlSubSystem.cpp
+++ b/src/StdSdlSubSystem.cpp
@@ -16,7 +16,7 @@
 #include "Standard.h"
 #include "StdSdlSubSystem.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include <stdexcept>
 #include <string>
@@ -25,7 +25,7 @@ using namespace std::string_literals;
 
 StdSdlSubSystem::StdSdlSubSystem(const Uint32 flags) : flags{flags}
 {
-	if (SDL_InitSubSystem(flags) != 0)
+	if (!SDL_InitSubSystem(flags))
 	{
 		throw std::runtime_error{"SDL_InitSubSystem failed: "s + SDL_GetError()};
 	}

--- a/src/StdSdlSubSystem.h
+++ b/src/StdSdlSubSystem.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include <utility>
 


### PR DESCRIPTION
Functional changes:

- Set window size directly on init call
- Improved double click so it takes OS settings for delay into account. (aka SDL is now on par with win32 version)
- Removed code from ApplyGammaToMonitor functions since SDL stopped supporting it
- When stopping music it now takes 100ms to fade out

That's all I know of

Known bugs:
- On Linux the rendered window is offset down by a 100px or so when the game starts in fullscreen. Setting to fullscreen in the options panel or tabbing in and out corrects it. Any pointers what the issue could be are appreciated ✌️

---
https://github.com/libsdl-org/SDL/releases/tag/release-3.4.2 
Windows: [SDL3-devel-3.4.2-VC.zip](https://github.com/libsdl-org/SDL/releases/download/release-3.4.2/SDL3-devel-3.4.2-VC.zip)
And the SDL Mixer 3 https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.0
Windows: [SDL3_mixer-devel-3.2.0-VC.zip](https://github.com/libsdl-org/SDL_mixer/releases/download/release-3.2.0/SDL3_mixer-devel-3.2.0-VC.zip)

Linux deps that I've build:
[SDL3Deps_Linux.zip](https://github.com/user-attachments/files/26615603/SDL3Deps_Linux.zip)
Please reach out in case I've missed a dependency file