### PR TITLE
Fix and improve Savegame thumbnails

### DIFF
--- a/src/C4Facet.cpp
+++ b/src/C4Facet.cpp
@@ -58,6 +58,19 @@ void C4Facet::Draw(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iPhaseX
 		iX, iY, Wdt, Hgt, true);
 }
 
+void C4Facet::DrawPart(C4Surface *const sfcTarget, const std::int32_t sourceWidth, const std::int32_t sourceHeight, const std::int32_t targetX, const std::int32_t targetY, const float scale) const
+{
+	if (!lpDDraw || !Surface || !sfcTarget || !sourceWidth || !sourceHeight)
+	{
+		return;
+	}
+
+	lpDDraw->Blit(Surface,
+		static_cast<float>(X) * scale, static_cast<float>(Y) * scale, static_cast<float>(sourceWidth) * scale, static_cast<float>(sourceHeight) * scale,
+		sfcTarget,
+		targetX, targetY, sourceWidth, sourceHeight, true);
+}
+
 void C4Facet::DrawT(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iPhaseX, int32_t iPhaseY, C4DrawTransform *pTransform, bool noScalingCorrection, const float scale)
 {
 	if (!lpDDraw || !Surface || !sfcTarget || !Wdt || !Hgt) return;
@@ -102,18 +115,18 @@ void C4Facet::Draw(C4Facet &cgo, bool fAspect, int32_t iPhaseX, int32_t iPhaseY,
 	// Valid parameter check
 	if (!lpDDraw || !Surface || !cgo.Surface || !Wdt || !Hgt) return;
 	// Drawing area
-	C4Facet ccgo = cgo;
+	C4Facet ccgo{cgo};
 	// Adjust for fixed aspect ratio
 	if (fAspect)
 	{
-		// By height
-		if (100 * cgo.Wdt / Wdt < 100 * cgo.Hgt / Hgt)
+		//    w1 : h1 <=> w2 : h2
+		// => w1 * h2 <=> w2 * h1
+		if (Wdt * cgo.Hgt > cgo.Wdt * Hgt)	// Scale height
 		{
 			ccgo.Hgt = Hgt * cgo.Wdt / Wdt;
 			ccgo.Y += (cgo.Hgt - ccgo.Hgt) / 2;
 		}
-		// By width
-		else if (100 * cgo.Hgt / Hgt < 100 * cgo.Wdt / Wdt)
+		else //  Scale width
 		{
 			ccgo.Wdt = Wdt * cgo.Hgt / Hgt;
 			ccgo.X += (cgo.Wdt - ccgo.Wdt) / 2;
@@ -125,6 +138,45 @@ void C4Facet::Draw(C4Facet &cgo, bool fAspect, int32_t iPhaseX, int32_t iPhaseY,
 		ccgo.Surface,
 		ccgo.X, ccgo.Y, ccgo.Wdt, ccgo.Hgt,
 		fTransparent);
+}
+
+void C4Facet::DrawVTile(C4FacetEx &cgo) const
+{
+	const std::int32_t x0{cgo.TargetX + cgo.X};
+	const std::int32_t y0{cgo.TargetY + cgo.Y};
+	std::int32_t y{0};
+	if (cgo.Wdt == Wdt)
+	{
+		// exact bar
+		while (Hgt > 0 && y < cgo.Hgt)
+		{
+			const auto hgt = std::min(Hgt, cgo.Hgt - y);
+			DrawPart(cgo.Surface, Wdt, hgt, x0, y0 + y);
+			y += hgt;
+		}
+	}
+	else
+	{
+		// zoomed bar
+		const auto zoom = static_cast<float>(cgo.Wdt) / Wdt;
+		const auto tileTargetHeight = static_cast<std::int32_t>(Hgt * zoom);
+		while (y < cgo.Hgt)
+		{
+			const std::int32_t targetHeight{std::min(static_cast<std::int32_t>(Hgt * zoom), cgo.Hgt - y)};
+			std::int32_t sourceHeight{Hgt};
+			if (targetHeight < tileTargetHeight)
+			{
+				sourceHeight = static_cast<std::int32_t>(targetHeight / zoom);
+			}
+			DrawXPart(cgo.Surface, Wdt, sourceHeight, x0, y0 + y, cgo.Wdt, targetHeight);
+			y += targetHeight;
+
+			if (targetHeight <= 0)
+			{
+				break;
+			}
+		}
+	}
 }
 
 void C4Facet::DrawFullScreen(C4Facet &cgo)
@@ -300,6 +352,20 @@ void C4Facet::DrawX(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iWdt, 
 		float(X + Wdt * iSectionX) * scale, float(Y + Hgt * iSectionY) * scale, float(Wdt) * scale, float(Hgt) * scale,
 		sfcTarget,
 		iX, iY, iWdt, iHgt,
+		true);
+}
+
+void C4Facet::DrawXPart(C4Surface *const sfcTarget, const std::int32_t sourceWidth, const std::int32_t sourceHeight, const std::int32_t targetX, const std::int32_t targetY, const std::int32_t targetWidth, const std::int32_t targetHeight, float scale) const
+{
+	if (!lpDDraw || !Surface || !sfcTarget || !sourceWidth || !sourceHeight)
+	{
+		return;
+	}
+
+	lpDDraw->Blit(Surface,
+		static_cast<float>(X) * scale, static_cast<float>(Y) * scale, static_cast<float>(sourceWidth) * scale, static_cast<float>(sourceHeight) * scale,
+		sfcTarget,
+		targetX, targetY, targetWidth, targetHeight,
 		true);
 }
 

--- a/src/C4Facet.h
+++ b/src/C4Facet.h
@@ -20,6 +20,8 @@
 
 #include <StdDDraw2.h>
 
+#include <cstdint>
+
 const int32_t C4FCT_None      = 0,
 
               C4FCT_Left      = 1,
@@ -129,6 +131,7 @@ public:
 	void Set(const C4Facet &cpy) { *this = cpy; }
 	void DrawEnergyLevelEx(int32_t iLevel, int32_t iRange, const C4Facet &gfx, int32_t bar_idx); // draw energy level using graphics
 	void DrawX(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iWdt, int32_t iHgt, int32_t iPhaseX = 0, int32_t iPhaseY = 0, float scale = 1.0f) const;
+	void DrawXPart(C4Surface *sfcTarget, std::int32_t sourceWidth, std::int32_t sourceHeight, std::int32_t targetX, std::int32_t targetY, std::int32_t targetWidth, std::int32_t targetHeight, float scale = 1.0f) const;
 	void DrawXFloat(C4Surface *sfcTarget, float fX, float fY, float fWdt, float fHgt) const;
 	void DrawValue(C4Facet &cgo, int32_t iValue, int32_t iPhaseX = 0, int32_t iPhaseY = 0, int32_t iAlign = C4FCT_Center);
 	void DrawValue2(C4Facet &cgo, int32_t iValue1, int32_t iValue2, int32_t iPhaseX = 0, int32_t iPhaseY = 0, int32_t iAlign = C4FCT_Center, int32_t *piUsedWidth = nullptr);
@@ -142,6 +145,8 @@ public:
 	void DrawXR(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iWdt, int32_t iHgt, int32_t iPhaseX = 0, int32_t iPhaseY = 0, int32_t r = 0); // draw rotated
 	void DrawClrMod(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iPhaseX = 0, int32_t iPhaseY = 0, uint32_t dwModClr = 0); // draw the facet modulated by given color
 	void Draw(C4Surface *sfcTarget, int32_t iX, int32_t iY, int32_t iPhaseX = 0, int32_t iPhaseY = 0, float scale = 1.0f);
+	void DrawPart(C4Surface *sfcTarget, std::int32_t sourceWidth, std::int32_t sourceHeight, std::int32_t targetX, std::int32_t targetY, float scale = 1.0f) const;
+	void DrawVTile(C4FacetEx &cgo) const;
 	bool GetPhaseNum(int32_t &rX, int32_t &rY); // return number of phases in this graphic
 	C4Facet GetSection(int32_t iSection);
 	C4Facet GetFraction(int32_t percentWdt, int32_t percentHgt = 0, int32_t alignX = C4FCT_Left, int32_t alignY = C4FCT_Top);

--- a/src/C4Game.cpp
+++ b/src/C4Game.cpp
@@ -2098,8 +2098,13 @@ bool C4Game::SaveGameTitle(C4Group &hGroup)
 			return false;
 		}
 
-		constexpr std::uint32_t titleWidth{200};
-		constexpr std::uint32_t titleHeight{150};
+		const auto srcWidth = static_cast<std::uint32_t>(screenshot->GetWidth());
+		const auto srcHeight = static_cast<std::uint32_t>(screenshot->GetHeight());
+		const auto srcSize = std::max(srcWidth, srcHeight);
+
+		constexpr std::uint32_t titleSize{400};
+		const std::uint32_t titleWidth{RoundedDivision(titleSize * srcWidth, srcSize)};
+		const std::uint32_t titleHeight{RoundedDivision(titleSize * srcHeight, srcSize)};
 		const StdBitmap thumbnail{screenshot->Scaled(titleWidth, titleHeight)};
 
 		try

--- a/src/C4Game.cpp
+++ b/src/C4Game.cpp
@@ -53,6 +53,7 @@
 
 #include <StdFile.h>
 #include <StdGL.h>
+#include <StdPNG.h>
 
 #include <format>
 #include <iterator>
@@ -2091,17 +2092,21 @@ bool C4Game::SaveGameTitle(C4Group &hGroup)
 	// Fullscreen screenshot
 	else if (Application.isFullScreen && Application.Active)
 	{
-		constexpr std::int32_t surfaceWidth{200};
-		constexpr std::int32_t surfaceHeight{150};
+		const auto screenshot = Application.DDraw->lpBack->CloneToBitmap(false, !Config.Graphics.Shader, false, Application.GetScale());
+		if (!screenshot)
+		{
+			return false;
+		}
 
-		const auto surface = std::make_unique<C4Surface>(surfaceWidth, surfaceHeight);
+		constexpr std::uint32_t titleWidth{200};
+		constexpr std::uint32_t titleHeight{150};
+		const StdBitmap thumbnail{screenshot->Scaled(titleWidth, titleHeight)};
 
-		// Fullscreen
-		Application.DDraw->Blit(Application.DDraw->lpBack,
-			0.0f, 0.0f, float(Application.DDraw->lpBack->Wdt), float(Application.DDraw->lpBack->Hgt),
-			surface.get(), 0, 0, surfaceWidth, surfaceHeight);
-
-		if (!surface->SavePNG(Config.AtTempPath(C4CFN_TempTitle), false, !Config.Graphics.Shader, false))
+		try
+		{
+			CPNGFile{Config.AtTempPath(C4CFN_TempTitle), titleWidth, titleHeight, false}.Encode(thumbnail.GetBytes());
+		}
+		catch (const std::runtime_error &)
 		{
 			return false;
 		}

--- a/src/C4Gui.cpp
+++ b/src/C4Gui.cpp
@@ -98,12 +98,106 @@ void DynBarFacet::SetHorizontal(C4Surface &rBySfc, int iHeight, int iBorderWidth
 	fctEnd.Set(&rBySfc, rBySfc.Wdt - iBorderWidth, 0, iBorderWidth, iHeight);
 }
 
-void DynBarFacet::SetHorizontal(C4Facet &rByFct, int32_t iBorderWidth)
+void DynBarFacet::SetHorizontal(const C4Facet &fromFacet, std::int32_t iBorderWidth)
 {
-	if (!iBorderWidth) iBorderWidth = rByFct.Hgt;
-	fctBegin.Set(rByFct.Surface, rByFct.X, rByFct.Y, iBorderWidth, rByFct.Hgt);
-	fctMiddle.Set(rByFct.Surface, rByFct.Hgt, rByFct.X, rByFct.Y + rByFct.Wdt - 2 * iBorderWidth, rByFct.Hgt);
-	fctEnd.Set(rByFct.Surface, rByFct.X + rByFct.Wdt - iBorderWidth, rByFct.Y, iBorderWidth, rByFct.Hgt);
+	if (!iBorderWidth)
+	{
+		iBorderWidth = fromFacet.Hgt;
+	}
+
+	fctBegin.Set(fromFacet.Surface, fromFacet.X, fromFacet.Y, iBorderWidth, fromFacet.Hgt);
+	fctMiddle.Set(fromFacet.Surface, iBorderWidth, fromFacet.Y, fromFacet.X + fromFacet.Wdt - 2 * iBorderWidth, fromFacet.Hgt);
+	fctEnd.Set(fromFacet.Surface, fromFacet.X + fromFacet.Wdt - iBorderWidth, fromFacet.Y, iBorderWidth, fromFacet.Hgt);
+}
+
+void DynBarFacet::Draw(C4FacetEx &cgo)
+{
+	if (cgo.Hgt == fctMiddle.Hgt)
+	{
+		// exact bar
+		const std::int32_t x0{cgo.TargetX + cgo.X};
+		const std::int32_t y0{cgo.TargetY + cgo.Y};
+		const std::int32_t w{fctMiddle.Wdt};
+		const std::int32_t endWidth{fctEnd.Wdt};
+		const std::int32_t iRightShowLength = endWidth;
+
+		std::int32_t x{fctBegin.Wdt};
+
+		{
+			const std::int32_t beginWidth{fctBegin.Wdt};
+			const bool overflows{beginWidth > cgo.Wdt};
+			if (overflows)
+			{
+				fctBegin.Wdt = cgo.Wdt;
+			}
+
+			fctBegin.Draw(cgo.Surface, x0, y0);
+
+			if (overflows)
+			{
+				fctBegin.Wdt = beginWidth;
+			}
+		}
+
+		while (x < cgo.Wdt - iRightShowLength)
+		{
+			const std::int32_t w2{std::min(w, cgo.Wdt - iRightShowLength - x)};
+			fctMiddle.Wdt = w2;
+			fctMiddle.Draw(cgo.Surface, x0 + x, y0);
+			x += w2;
+
+			if (w2 <= 0)
+			{
+				break;
+			}
+		}
+		fctMiddle.Wdt = w;
+
+		{
+			const bool overflows{endWidth > cgo.Wdt};
+			if (overflows)
+			{
+				fctEnd.X += endWidth - cgo.Wdt;
+				fctEnd.Wdt = cgo.Wdt;
+			}
+
+			fctEnd.Draw(cgo.Surface, x0 + cgo.Wdt - fctEnd.Wdt, y0);
+
+			if (overflows)
+			{
+				fctEnd.X -= endWidth - cgo.Wdt;
+				fctEnd.Wdt = endWidth;
+			}
+		}
+	}
+	else
+	{
+		// zoomed bar
+		const auto scale = static_cast<float>(cgo.Hgt) / fctMiddle.Hgt;
+		const std::int32_t x0{cgo.TargetX + cgo.X};
+		const std::int32_t y0{cgo.TargetY + cgo.Y};
+		const auto w = static_cast<std::int32_t>(scale * fctMiddle.Wdt);
+		const auto wOld = fctMiddle.Wdt;
+		const std::int32_t iRightShowLength{fctEnd.Wdt};
+
+		auto x = static_cast<std::int32_t>(scale * fctBegin.Wdt);
+
+		fctBegin.DrawX(cgo.Surface, x0, y0, static_cast<std::int32_t>(scale * fctBegin.Wdt), cgo.Hgt);
+		while (x < cgo.Wdt - (scale * iRightShowLength))
+		{
+			std::int32_t w2 = std::min(w, cgo.Wdt - static_cast<std::int32_t>(scale * iRightShowLength) - x);
+			fctMiddle.Wdt = static_cast<std::int32_t>(w2 / scale);
+			fctMiddle.DrawX(cgo.Surface, x0 + x, y0, w2, cgo.Hgt);
+			x += w2;
+
+			if (w2 <= 0)
+			{
+				break;
+			}
+		}
+		fctMiddle.Wdt = wOld;
+		fctEnd.DrawX(cgo.Surface, x0 + cgo.Wdt - static_cast<std::int32_t>(scale * fctEnd.Wdt), y0, static_cast<std::int32_t>(scale * fctEnd.Wdt), cgo.Hgt);
+	}
 }
 
 void ScrollBarFacets::Set(const C4Facet &rByFct, int32_t iPinIndex)

--- a/src/C4Gui.h
+++ b/src/C4Gui.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) RedWolf Design
  * Copyright (c) 2001, Sven2
- * Copyright (c) 2017-2024, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -384,8 +384,9 @@ struct DynBarFacet
 	C4Facet fctBegin, fctMiddle, fctEnd;
 
 	void SetHorizontal(C4Surface &rBySfc, int iHeight = 0, int iBorderWidth = 0);
-	void SetHorizontal(C4Facet &rByFct, int32_t iBorderWidth = 0);
+	void SetHorizontal(const C4Facet &fromFacet, std::int32_t iBorderWidth = 0);
 	void Clear() { fctBegin.Default(); fctMiddle.Default(); fctEnd.Default(); }
+	void Draw(C4FacetEx &cgo);
 };
 
 // facets used to draw a scroll bar
@@ -655,17 +656,28 @@ public:
 	void SetAnimated(bool fEnabled, int iDelay); // starts/stops cycling through all phases of the specified facet
 };
 
+struct OverlayFrameSpec
+{
+	OverlayFrameSpec() noexcept = default;
+	OverlayFrameSpec(const C4Facet &texture, std::int32_t horizontalFrameSize, std::int32_t verticalFrameSize) noexcept;
+
+	DynBarFacet Top;
+	DynBarFacet Bottom;
+	C4Facet LeftTile;
+	C4Facet RightTile;
+};
+
 // picture displaying two facets
 class OverlayPicture : public Picture
 {
 protected:
 	int iBorderSize; // border of overlay image if not zoomed
-	C4Facet OverlayImage; // image to be displayed on top of the actual picture
+	OverlayFrameSpec OverlayImage; // image to be displayed on top of the actual picture
 
 	virtual void DrawElement(C4FacetEx &cgo) override; // draw the image
 
 public:
-	OverlayPicture(const C4Rect &rcBounds, bool fAspect, const C4Facet &rOverlayImage, int iBorderSize); // does not load image
+	OverlayPicture(const C4Rect &rcBounds, bool fAspect, const OverlayFrameSpec &rOverlayImage, int iBorderSize); // does not load image
 };
 
 // icon indices
@@ -1280,7 +1292,10 @@ protected:
 	Picture *pTitlePicture; // [optional]: Picture shown atop the text
 	MultilineLabel *pLogBuffer; // buffer holding text data
 	bool fDrawBackground, fDrawFrame; // whether dark background should be drawn (default true)
-	size_t iPicPadding;
+	std::int32_t iPicPadding;
+	std::int32_t iPicWdt;
+	std::int32_t iPicHgt;
+	bool keepPictureAspectRatio;
 
 	virtual void DrawElement(C4FacetEx &cgo) override; // draw text window
 
@@ -1291,7 +1306,7 @@ protected:
 	virtual Control *IsFocusElement() override { return nullptr; } // no focus element for now, because there's nothing to do (2do: scroll?)
 
 public:
-	TextWindow(const C4Rect &rtBounds, size_t iPicWdt = 0, size_t iPicHgt = 0, size_t iPicPadding = 0, size_t iMaxLines = 100, size_t iMaxTextLen = 4096, const char *szIndentChars = "    ", bool fAutoGrow = false, const C4Facet *pOverlayPic = nullptr, int iOverlayBorder = 0, bool fMarkup = false);
+	TextWindow(const C4Rect &rtBounds, std::int32_t iPicWdt = 0, std::int32_t iPicHgt = 0, std::int32_t iPicPadding = 0, size_t iMaxLines = 100, size_t iMaxTextLen = 4096, const char *szIndentChars = "    ", bool fAutoGrow = false, const OverlayFrameSpec *pOverlayPic = nullptr, int iOverlayBorder = 0, bool fMarkup = false, bool keepPictureAspectRatio = false);
 
 	void AddTextLine(const char *szText, CStdFont *pFont, uint32_t dwClr, bool fDoUpdate, bool fMakeReadableOnBlack, CStdFont *pCaptionFont = nullptr) // add text in a new line
 	{

--- a/src/C4GuiLabels.cpp
+++ b/src/C4GuiLabels.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) RedWolf Design
  * Copyright (c) 2001, Sven2
- * Copyright (c) 2017-2023, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -25,6 +25,10 @@
 #include "C4GuiResource.h"
 #include "C4OpenURL.h"
 #include <C4Application.h>
+
+#include <cassert>
+#include <compare>
+#include <utility>
 
 namespace C4GUI
 {
@@ -401,26 +405,158 @@ void Picture::SetAnimated(bool fEnabled, int iDelay)
 	}
 }
 
+OverlayFrameSpec::OverlayFrameSpec(const C4Facet &texture, const std::int32_t horizontalFrameSize, const std::int32_t verticalFrameSize) noexcept
+{
+	const C4Facet top{texture.Surface, texture.X, texture.Y, texture.Wdt, verticalFrameSize};
+	const C4Facet bottom{texture.Surface, texture.X, texture.Y + texture.Hgt - verticalFrameSize, texture.Wdt, verticalFrameSize};
+
+	const auto verticalTileY = texture.Y + verticalFrameSize;
+	const auto verticalTileHgt = texture.Hgt - 2 * verticalFrameSize;
+	LeftTile = {texture.Surface, texture.X, verticalTileY, horizontalFrameSize, verticalTileHgt};
+	RightTile = {texture.Surface, texture.X + texture.Wdt - horizontalFrameSize, verticalTileY, horizontalFrameSize, verticalTileHgt};
+	Top.SetHorizontal(top, horizontalFrameSize);
+	Bottom.SetHorizontal(bottom, horizontalFrameSize);
+}
+
 // OverlayPicture
 
-OverlayPicture::OverlayPicture(const C4Rect &rcBounds, bool fAspect, const C4Facet &rOverlayImage, int iBorderSize)
+OverlayPicture::OverlayPicture(const C4Rect &rcBounds, bool fAspect, const OverlayFrameSpec &rOverlayImage, int iBorderSize)
 	: Picture(rcBounds, fAspect), iBorderSize(iBorderSize), OverlayImage(rOverlayImage) {}
 
 void OverlayPicture::DrawElement(C4FacetEx &cgo)
 {
+	const auto targetWidth = rcBounds.Wdt;
+	const auto targetHeight = rcBounds.Hgt;
+
+	const auto innerTargetWidth = targetWidth - 2 * iBorderSize;
+	const auto innerTargetHeight = targetHeight - 2 * iBorderSize;
+
+	std::int32_t drawWidth{targetWidth};
+	std::int32_t drawHeight{targetHeight};
+
+	C4FacetEx overlayCgo = cgo;
+
+	//    w1 : h1 <=> w2 : h2
+	// => w1 * h2 <=> w2 * h1
+	const auto aspectRatioRelation = Facet.Wdt * innerTargetHeight <=> innerTargetWidth * Facet.Hgt;
+	if (!fAspect || std::is_eq(aspectRatioRelation))
+	{
+		// draw outer image
+		overlayCgo.X = rcBounds.x;
+		overlayCgo.Y = rcBounds.y;
+		overlayCgo.Wdt = rcBounds.Wdt;
+		overlayCgo.Hgt = rcBounds.Hgt;
+	}
+	else if (std::is_gt(aspectRatioRelation)) // Scale height
+	{
+		drawHeight = Facet.Hgt * innerTargetWidth / Facet.Wdt + 2 * iBorderSize;
+		const auto drawOffsetY = (targetHeight - drawHeight) / 2;
+
+		overlayCgo.X = rcBounds.x;
+		overlayCgo.Y = rcBounds.y + drawOffsetY;
+		overlayCgo.Wdt = rcBounds.Wdt;
+		overlayCgo.Hgt = drawHeight;
+	}
+	else if (std::is_lt(aspectRatioRelation)) // Scale width
+	{
+		drawWidth = Facet.Wdt * innerTargetHeight / Facet.Hgt + 2 * iBorderSize;
+		const auto drawOffsetX = (targetWidth - drawWidth) / 2;
+
+		overlayCgo.X = rcBounds.x + drawOffsetX;
+		overlayCgo.Y = rcBounds.y;
+		overlayCgo.Wdt = drawWidth;
+		overlayCgo.Hgt = rcBounds.Hgt;
+	}
+	else
+	{
+		assert(!"Aspect ratio comparison logic failed");
+	}
+
+	const auto minUnscaledOverlayWdt = OverlayImage.Top.fctBegin.Wdt + OverlayImage.Top.fctEnd.Wdt;
+	const auto minUnscaledOverlayHgt = OverlayImage.Top.fctBegin.Hgt + OverlayImage.Bottom.fctBegin.Hgt;
+	const auto [overlayScaleNumerator, overlayScaleDenominator] = [minUnscaledOverlayWdt, minUnscaledOverlayHgt, &overlayCgo]
+	{
+		const auto hgtScaleDenominator = std::max(minUnscaledOverlayHgt, overlayCgo.Hgt);
+		const auto wdtScaleDenominator = std::max(minUnscaledOverlayWdt, overlayCgo.Wdt);
+
+		//    w1 : h1 <=> w2 : h2
+		// => w1 * h2 <=> w2 * h1
+		if (wdtScaleDenominator * overlayCgo.Hgt < hgtScaleDenominator * overlayCgo.Wdt)
+		{
+			return std::pair{overlayCgo.Hgt, hgtScaleDenominator};
+		}
+		else
+		{
+			return std::pair{overlayCgo.Wdt, wdtScaleDenominator};
+		}
+	}();
+	const auto scaleOverlay = [overlayScaleNumerator, overlayScaleDenominator](std::int32_t value, bool ceil = false)
+	{
+		return (value * overlayScaleNumerator + ceil * (overlayScaleDenominator - 1)) / overlayScaleDenominator;
+	};
+
+	const auto scaledBorderSize = scaleOverlay(iBorderSize, true);
+
 	// draw inner image
-	C4Facet cgo2 = cgo;
-	cgo2.X = rcBounds.x + cgo.TargetX + iBorderSize * rcBounds.Wdt / std::max<int>(OverlayImage.Wdt, 1);
-	cgo2.Y = rcBounds.y + cgo.TargetY + iBorderSize * rcBounds.Hgt / std::max<int>(OverlayImage.Hgt, 1);
-	cgo2.Wdt = rcBounds.Wdt - 2 * iBorderSize * rcBounds.Wdt / std::max<int>(OverlayImage.Wdt, 1);
-	cgo2.Hgt = rcBounds.Hgt - 2 * iBorderSize * rcBounds.Hgt / std::max<int>(OverlayImage.Hgt, 1);
-	Facet.Draw(cgo2, fAspect);
-	// draw outer image
-	cgo2.X = rcBounds.x + cgo.TargetX;
-	cgo2.Y = rcBounds.y + cgo.TargetY;
-	cgo2.Wdt = rcBounds.Wdt;
-	cgo2.Hgt = rcBounds.Hgt;
-	OverlayImage.Draw(cgo2, fAspect);
+	C4Facet innerCgo{cgo};
+	innerCgo.X = overlayCgo.X + cgo.TargetX + scaledBorderSize;
+	innerCgo.Y = overlayCgo.Y + cgo.TargetY + scaledBorderSize;
+	innerCgo.Wdt = overlayCgo.Wdt - 2 * scaledBorderSize;
+	innerCgo.Hgt = overlayCgo.Hgt - 2 * scaledBorderSize;
+	Facet.Draw(innerCgo, true);
+
+
+	if (!fAspect || std::is_eq(aspectRatioRelation))
+	{
+		// draw outer image
+		overlayCgo.X = rcBounds.x;
+		overlayCgo.Y = rcBounds.y;
+		overlayCgo.Wdt = rcBounds.Wdt;
+		overlayCgo.Hgt = rcBounds.Hgt;
+	}
+	else if (std::is_gt(aspectRatioRelation))	 // Scale height
+	{
+		drawHeight = innerCgo.Wdt * Facet.Hgt / Facet.Wdt + 2 * scaledBorderSize;
+		const auto drawOffsetY = (targetHeight - drawHeight) / 2;
+
+		overlayCgo.X = rcBounds.x;
+		overlayCgo.Y = rcBounds.y + drawOffsetY;
+		overlayCgo.Wdt = rcBounds.Wdt;
+		overlayCgo.Hgt = drawHeight;
+	}
+	else if (std::is_lt(aspectRatioRelation)) //  Scale width
+	{
+		drawWidth = innerCgo.Hgt * Facet.Wdt / Facet.Hgt + 2 * scaledBorderSize;
+		const auto drawOffsetX = (targetWidth - drawWidth) / 2;
+
+		overlayCgo.X = rcBounds.x + drawOffsetX;
+		overlayCgo.Y = rcBounds.y;
+		overlayCgo.Wdt = drawWidth;
+		overlayCgo.Hgt = rcBounds.Hgt;
+	}
+
+	C4FacetEx topBarCgo{overlayCgo};
+	topBarCgo.Hgt = scaleOverlay(OverlayImage.Top.fctBegin.Hgt);
+
+	C4FacetEx bottomBarCgo{overlayCgo};
+	bottomBarCgo.Hgt = scaleOverlay(OverlayImage.Bottom.fctBegin.Hgt);
+	bottomBarCgo.Y += overlayCgo.Hgt - bottomBarCgo.Hgt;
+
+	C4FacetEx leftBarCgo{overlayCgo};
+	leftBarCgo.Wdt = scaleOverlay(OverlayImage.LeftTile.Wdt);
+	leftBarCgo.Y += topBarCgo.Hgt;
+	leftBarCgo.Hgt = overlayCgo.Hgt - topBarCgo.Hgt - bottomBarCgo.Hgt;
+
+	C4FacetEx rightBarCgo{overlayCgo};
+	rightBarCgo.Wdt = scaleOverlay(OverlayImage.RightTile.Wdt);
+	rightBarCgo.X += overlayCgo.Wdt - rightBarCgo.Wdt;
+	rightBarCgo.Y += topBarCgo.Hgt;
+	rightBarCgo.Hgt = overlayCgo.Hgt - topBarCgo.Hgt - bottomBarCgo.Hgt;
+
+	OverlayImage.Top.Draw(topBarCgo);
+	OverlayImage.Bottom.Draw(bottomBarCgo);
+	OverlayImage.LeftTile.DrawVTile(leftBarCgo);
+	OverlayImage.RightTile.DrawVTile(rightBarCgo);
 }
 
 // Icon
@@ -451,8 +587,8 @@ C4FacetEx Icon::GetIconFacet(Icons icoIconIndex)
 
 // TextWindow
 
-TextWindow::TextWindow(const C4Rect &rtBounds, size_t iPicWdt, size_t iPicHgt, size_t iPicPadding, size_t iMaxLines, size_t iMaxTextLen, const char *szIndentChars, bool fAutoGrow, const C4Facet *pOverlayPic, int iOverlayBorder, bool fMarkup)
-	: Control(rtBounds), pLogBuffer(nullptr), fDrawBackground(true), fDrawFrame(true), iPicPadding(iPicPadding)
+TextWindow::TextWindow(const C4Rect &rtBounds, const std::int32_t iPicWdt, const std::int32_t iPicHgt, const std::int32_t iPicPadding, const size_t iMaxLines, const size_t iMaxTextLen, const char *const szIndentChars, const bool fAutoGrow, const OverlayFrameSpec *pOverlayPic, const int iOverlayBorder, const bool fMarkup, const bool keepPictureAspectRatio)
+	: Control(rtBounds), pLogBuffer(nullptr), fDrawBackground(true), fDrawFrame(true), iPicPadding(iPicPadding), iPicWdt(iPicWdt), iPicHgt(iPicHgt), keepPictureAspectRatio(keepPictureAspectRatio)
 {
 	// calc client rect
 	UpdateOwnPos();
@@ -469,16 +605,14 @@ TextWindow::TextWindow(const C4Rect &rtBounds, size_t iPicWdt, size_t iPicHgt, s
 	C4Rect rcContentSize = pClientWindow->GetClientRect();
 	if (iPicWdt && iPicHgt)
 	{
-		C4Rect rcImage;
-		rcImage.x = std::max<int32_t>(rcContentSize.GetMiddleX() - iPicWdt / 2, 0);
-		rcImage.y = 0;
-		rcImage.Wdt = std::min<size_t>(iPicWdt, rcContentSize.Wdt);
-		rcImage.Hgt = iPicHgt * rcImage.Wdt / iPicWdt;
+		const auto imageWidth = rcContentSize.Wdt;
+		const auto imageHeight = keepPictureAspectRatio ? iPicHgt : iPicHgt * imageWidth / iPicWdt;
+		const C4Rect rcImage{0, 0, imageWidth, imageHeight};
 		rcContentSize.y += rcImage.Hgt + iPicPadding;
 		if (pOverlayPic)
-			pTitlePicture = new OverlayPicture(rcImage, false, *pOverlayPic, iOverlayBorder);
+			pTitlePicture = new OverlayPicture(rcImage, keepPictureAspectRatio, *pOverlayPic, iOverlayBorder);
 		else
-			pTitlePicture = new Picture(rcImage, false);
+			pTitlePicture = new Picture(rcImage, keepPictureAspectRatio);
 		pClientWindow->AddElement(pTitlePicture);
 	}
 	else pTitlePicture = nullptr;
@@ -497,6 +631,26 @@ void TextWindow::UpdateSize()
 	rcChildBounds.y = pTitlePicture ? pTitlePicture->GetBounds().Hgt + iPicPadding : 0;
 	rcChildBounds.Wdt = pClientWindow->GetClientRect().Wdt;
 	pLogBuffer->SetBounds(rcChildBounds);
+
+	C4Rect rcContentSize = pClientWindow->GetClientRect();
+	if (pTitlePicture != nullptr)
+	{
+		C4Rect rcImage;
+		rcImage.x = 0;
+		rcImage.y = 0;
+		rcImage.Wdt = rcContentSize.Wdt;
+
+		if (keepPictureAspectRatio)
+		{
+			rcImage.Hgt = iPicHgt;
+		}
+		else
+		{
+			rcImage.Hgt = iPicHgt * rcImage.Wdt / iPicWdt;
+		}
+		rcContentSize.y += rcImage.Hgt + iPicPadding;
+		pTitlePicture->SetBounds(rcImage);
+	}
 }
 
 void TextWindow::DrawElement(C4FacetEx &cgo)

--- a/src/C4Startup.cpp
+++ b/src/C4Startup.cpp
@@ -67,8 +67,14 @@ bool C4StartupGraphics::Init()
 	if (!LoadFile(fctScenSelIcons, "StartupScenSelIcons")) return false;
 	Game.SetInitProgress(68);
 	fctScenSelIcons.Wdt = fctScenSelIcons.Hgt; // icon width is determined by icon height
-	if (!LoadFile(fctScenSelTitleOverlay, "StartupScenSelTitleOv")) return false;
+
+	if (!LoadFile(fctScenSelTitleOverlay, "StartupScenSelTitleOv"))
+	{
+		return false;
+	}
+	scenSelTitleOverlayFrame = {fctScenSelTitleOverlay, 31, 29};
 	Game.SetInitProgress(70);
+
 	if (!LoadFile(fctPlrCtrlType, "StartupPlrCtrlType")) return false;
 	fctPlrCtrlType.Set(fctPlrCtrlType.Surface, 0, 0, 128, 52);
 	Game.SetInitProgress(72);

--- a/src/C4Startup.h
+++ b/src/C4Startup.h
@@ -62,6 +62,7 @@ public:
 	C4FacetExID fctScenSelIcons;
 	// scenario selection: Title overlay
 	C4FacetExID fctScenSelTitleOverlay;
+	C4GUI::OverlayFrameSpec scenSelTitleOverlayFrame;
 	// scenario selection and player selection book fonts
 	CStdFont BookFontCapt, BookFont, BookFontTitle, BookSmallFont;
 

--- a/src/C4StartupAboutDlg.cpp
+++ b/src/C4StartupAboutDlg.cpp
@@ -161,7 +161,7 @@ template<int32_t left, int32_t top, int32_t right, int32_t bottom>
 class CustomMarginTextWindow : public C4GUI::TextWindow
 {
 public:
-	CustomMarginTextWindow(C4Rect &rtBounds, size_t iPicWdt = 0, size_t iPicHgt = 0, size_t iPicPadding = 0, size_t iMaxLines = 100, size_t iMaxTextLen = 4096, const char *szIndentChars = "    ", bool fAutoGrow = false, const C4Facet *pOverlayPic = nullptr, int iOverlayBorder = 0, bool fMarkup = false) : C4GUI::TextWindow{rtBounds, iPicWdt, iPicHgt, iPicPadding, iMaxLines, iMaxTextLen, szIndentChars, fAutoGrow, pOverlayPic, iOverlayBorder, fMarkup}
+	CustomMarginTextWindow(C4Rect &rtBounds, std::int32_t iPicWdt = 0, std::int32_t iPicHgt = 0, std::int32_t iPicPadding = 0, size_t iMaxLines = 100, size_t iMaxTextLen = 4096, const char *szIndentChars = "    ", bool fAutoGrow = false, const C4GUI::OverlayFrameSpec *pOverlayPic = nullptr, int iOverlayBorder = 0, bool fMarkup = false) : C4GUI::TextWindow{rtBounds, iPicWdt, iPicHgt, iPicPadding, iMaxLines, iMaxTextLen, szIndentChars, fAutoGrow, pOverlayPic, iOverlayBorder, fMarkup}
 	{
 		UpdateSize();
 	}

--- a/src/C4StartupScenSelDlg.cpp
+++ b/src/C4StartupScenSelDlg.cpp
@@ -387,7 +387,7 @@ void C4MapFolderData::CreateGUIElements(C4StartupScenSelDlg *pMainDlg, C4GUI::Wi
 	// create scenario info listbox
 	pSelectionInfoBox = new C4GUI::TextWindow(rcScenInfoArea,
 		C4StartupScenSel_TitlePictureWdt + 2 * C4StartupScenSel_TitleOverlayMargin, C4StartupScenSel_TitlePictureHgt + 2 * C4StartupScenSel_TitleOverlayMargin,
-		C4StartupScenSel_TitlePicturePadding, 100, 4096, nullptr, true, &C4Startup::Get()->Graphics.fctScenSelTitleOverlay, C4StartupScenSel_TitleOverlayMargin);
+		C4StartupScenSel_TitlePicturePadding, 100, 4096, nullptr, true, &C4Startup::Get()->Graphics.scenSelTitleOverlayFrame, C4StartupScenSel_TitleOverlayMargin);
 	pSelectionInfoBox->SetDecoration(false, false, &C4Startup::Get()->Graphics.sfctBookScroll, true);
 	rContainer.AddElement(pSelectionInfoBox);
 }
@@ -1373,7 +1373,7 @@ C4StartupScenSelDlg::C4StartupScenSelDlg(bool fNetwork) : C4StartupDlg(LoadResSt
 
 	// right side of book: Displaying current selection
 	pSelectionInfo = new C4GUI::TextWindow(caBook.GetFromRight(iBookPageWidth), C4StartupScenSel_TitlePictureWdt + 2 * C4StartupScenSel_TitleOverlayMargin, C4StartupScenSel_TitlePictureHgt + 2 * C4StartupScenSel_TitleOverlayMargin,
-		C4StartupScenSel_TitlePicturePadding, 100, 4096, nullptr, true, &C4Startup::Get()->Graphics.fctScenSelTitleOverlay, C4StartupScenSel_TitleOverlayMargin);
+		C4StartupScenSel_TitlePicturePadding, 100, 4096, nullptr, true, &C4Startup::Get()->Graphics.scenSelTitleOverlayFrame, C4StartupScenSel_TitleOverlayMargin, false, true);
 	pSelectionInfo->SetDecoration(false, false, &C4Startup::Get()->Graphics.sfctBookScroll, true);
 	pSheetBook->AddElement(pSelectionInfo);
 

--- a/src/C4Surface.cpp
+++ b/src/C4Surface.cpp
@@ -2,7 +2,7 @@
  * LegacyClonk
  *
  * Copyright (c) 1998-2000, Matthes Bender (RedWolf Design)
- * Copyright (c) 2017-2024, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -419,60 +419,89 @@ bool C4Surface::Read(C4Group &hGroup, bool fOwnPal)
 
 bool C4Surface::SavePNG(const char *szFilename, bool fSaveAlpha, bool fApplyGamma, bool fSaveOverlayOnly, float scale)
 {
-	// Lock - WARNING - maybe locking primary surface here...
-	if (!Lock()) return false;
-
-	if (lpDDraw->Gamma.GetSize() == 0)
-		fApplyGamma = false;
-
-	int realWdt = static_cast<int32_t>(ceilf(Wdt * scale));
-	int realHgt = static_cast<int32_t>(ceilf(Hgt * scale));
-
-	// Create bitmap
-	StdBitmap bmp(realWdt, realHgt, fSaveAlpha);
-
-	// reset overlay if desired
-	C4Surface *pMainSfcBackup;
-	if (fSaveOverlayOnly) { pMainSfcBackup = pMainSfc; pMainSfc = nullptr; }
-
-#ifndef USE_CONSOLE
-	if (fPrimary && pGL)
+	const auto bmp = CloneToBitmap(fSaveAlpha, fApplyGamma, fSaveOverlayOnly, scale);
+	if (!bmp)
 	{
-		// Take shortcut. FIXME: Check Endian
-		for (int y = 0; y < realHgt; ++y)
-			glReadPixels(0, realHgt - y, realWdt, 1, fSaveAlpha ? GL_BGRA : GL_BGR, GL_UNSIGNED_BYTE, bmp.GetPixelAddr(0, y));
+		return false;
 	}
-	else
-#endif
-	{
-		// write pixel values
-		for (int y = 0; y < realHgt; ++y)
-			for (int x = 0; x < realWdt; ++x)
-			{
-				uint32_t dwClr = GetPixDw(x, y, false, scale);
-				if (fApplyGamma) dwClr = lpDDraw->Gamma.ApplyTo(dwClr);
-				bmp.SetPixel(x, y, dwClr);
-			}
-	}
-
-	// reset overlay
-	if (fSaveOverlayOnly) pMainSfc = pMainSfcBackup;
-
-	// Unlock
-	Unlock();
 
 	// Save bitmap to PNG file
 	try
 	{
-		CPNGFile(szFilename, realWdt, realHgt, fSaveAlpha).Encode(bmp.GetBytes());
+		CPNGFile{szFilename, bmp->GetWidth(), bmp->GetHeight(), fSaveAlpha}.Encode(bmp->GetBytes());
 	}
 	catch (const std::runtime_error &)
 	{
 		return false;
 	}
 
-	// Success
 	return true;
+}
+
+std::optional<StdBitmap> C4Surface::CloneToBitmap(const bool withAlpha, bool applyGamma, const bool overlayOnly, const float scale)
+{
+	// Lock - WARNING - maybe locking primary surface here...
+	if (!Lock())
+	{
+		return std::nullopt;
+	}
+
+	if (lpDDraw->Gamma.GetSize() == 0)
+	{
+		applyGamma = false;
+	}
+
+	const auto realWdt = static_cast<int>(std::ceilf(Wdt * scale));
+	const auto realHgt = static_cast<int>(std::ceilf(Hgt * scale));
+
+	// Create bitmap
+	std::optional<StdBitmap> result{std::in_place, static_cast<std::uint32_t>(realWdt), static_cast<std::uint32_t>(realHgt), withAlpha};
+
+	// reset overlay if desired
+	C4Surface *mainSfcBackup{};
+	if (overlayOnly)
+	{
+		mainSfcBackup = pMainSfc;
+		pMainSfc = nullptr;
+	}
+
+#ifndef USE_CONSOLE
+	if (fPrimary && pGL)
+	{
+		// Take shortcut. FIXME: Check Endian
+		for (int y = 0; y < realHgt; ++y)
+		{
+			glReadPixels(0, realHgt - y, realWdt, 1, withAlpha ? GL_BGRA : GL_BGR, GL_UNSIGNED_BYTE, result->GetPixelAddr(0, y));
+		}
+	}
+	else
+#endif
+	{
+		// write pixel values
+		for (int y = 0; y < realHgt; ++y)
+		{
+			for (int x = 0; x < realWdt; ++x)
+			{
+				std::uint32_t dwClr = GetPixDw(x, y, false, scale);
+				if (applyGamma)
+				{
+					dwClr = lpDDraw->Gamma.ApplyTo(dwClr);
+				}
+				result->SetPixel(x, y, dwClr);
+			}
+		}
+	}
+
+	// reset overlay
+	if (overlayOnly)
+	{
+		pMainSfc = mainSfcBackup;
+	}
+
+	// Unlock
+	Unlock();
+
+	return result;
 }
 
 bool C4Surface::Wipe()

--- a/src/C4Surface.h
+++ b/src/C4Surface.h
@@ -2,7 +2,7 @@
  * LegacyClonk
  *
  * Copyright (c) 1998-2000, Matthes Bender (RedWolf Design)
- * Copyright (c) 2017-2024, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -20,6 +20,7 @@
 
 #include "C4Rect.h"
 #include "Standard.h"
+#include "StdBitmap.h"
 #include "StdColors.h"
 
 #ifndef USE_CONSOLE
@@ -27,6 +28,7 @@
 #endif
 
 #include <list>
+#include <optional>
 
 // config settings
 #define C4GFXCFG_NO_ALPHA_ADD    1
@@ -118,6 +120,7 @@ public:
 	bool Copy(C4Surface &fromSfc);
 	bool ReadPNG(C4Group &hGroup);
 	bool ReadJPEG(C4Group &hGroup);
+	std::optional<StdBitmap> CloneToBitmap(bool withAlpha, bool applyGamma, bool overlayOnly, float scale);
 
 private:
 	bool CreateTextures(); // create ppTex-array

--- a/src/StdBitmap.cpp
+++ b/src/StdBitmap.cpp
@@ -1,7 +1,7 @@
 /*
  * LegacyClonk
  *
- * Copyright (c) 2017-2019, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -92,4 +92,37 @@ void StdBitmap::SetPixel24(const std::uint32_t x, const std::uint32_t y, const s
 void StdBitmap::SetPixel32(const std::uint32_t x, const std::uint32_t y, const std::uint32_t value)
 {
 	*static_cast<std::uint32_t *>(GetPixelAddr32(x, y)) = value;
+}
+
+std::uint32_t StdBitmap::GetWidth() const noexcept
+{
+	return width;
+}
+
+std::uint32_t StdBitmap::GetHeight() const noexcept
+{
+	return height;
+}
+
+StdBitmap StdBitmap::Scaled(const std::uint32_t targetWidth, const std::uint32_t targetHeight) const
+{
+	StdBitmap result{targetWidth, targetHeight, useAlpha};
+
+	constexpr auto scaleCoordinate = [](const std::uint32_t target, const std::uint32_t targetSize, const std::uint32_t sourceSize)
+	{
+		// for this purpose pixels are considered to be positioned in the center between two coordinates
+		return static_cast<std::uint32_t>((target + 0.5) * sourceSize / targetSize);
+	};
+
+	for (std::uint32_t targetY{0}; targetY < targetHeight; ++targetY)
+	{
+		for (std::uint32_t targetX{0}; targetX < targetWidth; ++targetX)
+		{
+			const auto srcX = scaleCoordinate(targetX, targetWidth, width);
+			const auto srcY = scaleCoordinate(targetY, targetHeight, height);
+			result.SetPixel(targetX, targetY, GetPixel(srcX, srcY));
+		}
+	}
+
+	return result;
 }

--- a/src/StdBitmap.h
+++ b/src/StdBitmap.h
@@ -1,7 +1,7 @@
 /*
  * LegacyClonk
  *
- * Copyright (c) 2017-2019, The LegacyClonk Team and contributors
+ * Copyright (c) 2017-2026, The LegacyClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -53,8 +53,13 @@ public:
 	// Sets the color of the pixel at the specified position, assuming the bitmap is in B8G8R8A8 format.
 	void SetPixel32(std::uint32_t x, std::uint32_t y, std::uint32_t value);
 
+	std::uint32_t GetWidth() const noexcept;
+	std::uint32_t GetHeight() const noexcept;
+
+	StdBitmap Scaled(std::uint32_t targetWidth, std::uint32_t targetHeight) const;
+
 private:
 	std::uint32_t width, height;
 	bool useAlpha;
-	const std::unique_ptr<std::uint8_t[]> bytes;
+	std::unique_ptr<std::uint8_t[]> bytes;
 };

--- a/src/StdHelpers.h
+++ b/src/StdHelpers.h
@@ -55,6 +55,12 @@ To checked_cast(From from)
 	return static_cast<To>(from);
 }
 
+template<std::integral T>
+constexpr T RoundedDivision(T numerator, T denominator) noexcept
+{
+	return (numerator + denominator / 2) / denominator;
+}
+
 template<typename... T>
 class StdOverloadedCallable : public T...
 {


### PR DESCRIPTION
- Fix taking savegame thumbnail screenshot when scaling is not 100% (Fixes #142)
- Support arbitrary aspect ratio for thumbnails in scenario selection (aspect ratio is preserved)
- Don’t force aspect ratio of thumbnail screenshots (so they don’t get stretched)